### PR TITLE
added "cafile" and "insecure" command line options for handling SSL connections

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -3,6 +3,8 @@
 
 var request = require('request');
 var url = require('url');
+var fs = require('fs');
+var _ = require('underscore');
 
 var DefaultBaseURI = 'https://api.enterprise.apigee.com';
 var DefaultAsyncLimit = 4;
@@ -47,6 +49,15 @@ var DefaultDescriptor = {
     name: 'JSON',
     shortOption: 'j',
     toggle: true
+  },
+  cafile: {
+    name: 'CA file',
+    shortOption: 'c'
+  },
+  insecure: {
+    name: 'insecure',
+    shortOption: 'k',
+    toggle: true
   }
 };
 
@@ -81,7 +92,8 @@ module.exports.defaultRequest = function(opts) {
       username: opts.username,
       password: opts.password.getValue()
     },
-    json: true
+    json: true,
+    agentOptions: {}
   };
 
   if (opts.baseuri) {
@@ -94,6 +106,22 @@ module.exports.defaultRequest = function(opts) {
                 process.env.http_proxy) {
       opts.proxy = process.env.http_proxy;
     }
+  }
+
+
+  if (opts.cafile) {
+    var files = opts.cafile.split(','),
+      ca = [];
+
+    _.each(files, function(file) {
+        ca.push(fs.readFileSync(file))
+    });
+
+    ro.agentOptions.ca = ca;
+  }
+
+  if (opts.insecure) {
+    ro.agentOptions.rejectUnauthorized = false;
   }
 
   return request.defaults(ro);


### PR DESCRIPTION
This simple change adds two command line options:
 
* `cafile` - comma delimited list of files containing CA certificates for server certificate validation
* `insecure` - flag, if set, the validation of the server certificate is disabled (not recommended, unless in testing environment)

Basically, the CA files taken from the `cafile` parameter are loaded into an array and passed as the `ca` parameter to the `agentOptions` section. If the `insecure` flag is set, `rejectUnauthorized: false` is set to the same section. The `agentOptions` object will be eventually used for the Node.js TLS connection - http://nodejs.org/api/tls.html#tls_tls_connect_port_host_options_callback.

You may take this PR as an inspiration, but in my company we actually need this feature very much, so I'll be glad, if it's available in the official apigeetool distribution.