### PR TITLE
Add pre and post flow to node.js proxies

### DIFF
--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -497,6 +497,8 @@ function handleUploadResult(err, req, fileName, itemDone) {
 function createTarget(opts, request, done) {
   var targetDoc = mustache.render(
     '<TargetEndpoint name="default">' +
+    '<PreFlow name="PreFlow"/>' +
+    '<PostFlow name="PostFlow"/>' +
     '<ScriptTarget>' +
     '<ResourceURL>node://{{main}}</ResourceURL>' +
     '</ScriptTarget>' +
@@ -532,6 +534,8 @@ function createProxy(opts, request, done) {
 
   var targetDoc = mustache.render(
     '<ProxyEndpoint name="default">' +
+    '<PreFlow name="PreFlow"/>' +
+    '<PostFlow name="PostFlow"/>' +
     '<HTTPProxyConnection>' +
     '<BasePath>{{basepath}}</BasePath>' +
     '{{#vhosts}}<VirtualHost>{{name}}</VirtualHost>{{/vhosts}}' +


### PR DESCRIPTION
Added pre and post flows to node.js proxies in edge. Matches behavior
when creating node.js proxy through UI and makes it easier to drop
policies onto the created proxies.