### PR TITLE
removed setting base-path when deploying a revision

### DIFF
--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -590,9 +590,7 @@ function deployProxy(opts, request, done) {
     if (opts.debug) { console.log('Going to POST to %s', uri); }
 
     var deployCmd = util.format('action=deploy&override=true&delay=%d', DeploymentDelay);
-    if (opts['base-path']) {
-      deployCmd = util.format('%s&basepath=%s', deployCmd, opts['base-path']);
-    }
+
     if (opts.debug) { console.log('Going go send command %s', deployCmd); }
 
     request({


### PR DESCRIPTION
When using this to deploy an already existing proxy, it created the new revision correctly, but when it did the deploy, it did not undeploy the old revision, so we ended up with two revisions deployed to the same environment. 
eg we have revision 2 deployed to environment test
we use apigetool to deploy a new version from source control to environment test
revision 3 is created and deployed
When looking at deployments, revision 2 and revision 3 are both showing as deployed to test

To fix this, we had to undeploy revision 2, undeploy revision 3 and then deploy revision 3 again

It seems to be setting base-path in the deploy API call that is causing the issue. Removing it seems to fix the issue