### PR TITLE
fix skipped files call itemDone

### DIFF
--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -346,13 +346,13 @@ function uploadPolicies(opts, request, done) {
       if (opts.verbose) {
         console.log('Skipping file %s which is not an XML file', rp);
       }
-      return;
+      return itemDone();
     }
     if (!stat.isFile()) {
       if (opts.verbose) {
         console.log('Skipping file %s which is not a regular file', rp);
       }
-      return;
+      return itemDone();
     }
 
     if (opts.verbose) {
@@ -410,13 +410,13 @@ function uploadTargets(opts, request, done) {
       if (opts.verbose) {
         console.log('Skipping file %s which is not an XML file', rp);
       }
-      return;
+      return itemDone();
     }
     if (!stat.isFile()) {
       if (opts.verbose) {
         console.log('Skipping file %s which is not a regular file', rp);
       }
-      return;
+      return itemDone();
     }
 
     if (opts.verbose) {
@@ -474,13 +474,13 @@ function uploadProxies(opts, request, done) {
       if (opts.verbose) {
         console.log('Skipping file %s which is not an XML file', rp);
       }
-      return;
+      return itemDone();
     }
     if (!stat.isFile()) {
       if (opts.verbose) {
         console.log('Skipping file %s which is not a regular file', rp);
       }
-      return;
+      return itemDone();
     }
 
     if (opts.verbose) {


### PR DESCRIPTION
in the Upload* functions, files that are skipped now call ```return itemDone()``` instead of just ```return```.  This allows the ```async.eachLimit``` to finish execution.