### PR TITLE
Add the ability to read credential from .netrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Currently this only affects file uploads in the `deploynodeapp` command. Default
 `--username  -u`  
 (required) Your Apigee account username. May be set as an environment variable APIGEE_USERNAME.
 
+`--netrc  -n`  
+(optional) Use this in lieu of -u / -p, to tell apigeetool to retrieve credentials from your .netrc file.
+
 `--verbose   -V`  
 (optional) Prints additional information as the deployment proceeds.
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -5,6 +5,7 @@ var request = require('request');
 var url = require('url');
 var fs = require('fs');
 var _ = require('underscore');
+var netrc = require('netrc')();
 
 var DefaultBaseURI = 'https://api.enterprise.apigee.com';
 var DefaultAsyncLimit = 4;
@@ -25,6 +26,12 @@ var DefaultDescriptor = {
     shortOption: 'p',
     required: true,
     secure: true
+  },
+  netrc: {
+    name: 'netrc',
+    shortOption: 'n',
+    required: false,
+    toggle: true
   },
   organization: {
     name: 'Organization',
@@ -92,11 +99,20 @@ module.exports.defaultOptions = function(opts) {
   if (!opts.organization) {
     opts.organization = process.env['APIGEE_ORGANIZATION'];
   }
-  if (!opts.username) {
-    opts.username = process.env['APIGEE_USERNAME'];
+  if (opts.netrc) {
+    var mgmtUrl = url.parse(opts.baseuri);
+    if (netrc[mgmtUrl.hostname]) {
+      opts.username = netrc[mgmtUrl.hostname].login;
+      opts.password = netrc[mgmtUrl.hostname].password;
+    }
   }
-  if (!opts.password) {
-    opts.password = process.env['APIGEE_PASSWORD'];
+  else {
+    if (!opts.username) {
+      opts.username = process.env['APIGEE_USERNAME'];
+    }
+    if (!opts.password) {
+      opts.password = process.env['APIGEE_PASSWORD'];
+    }
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "read": "^1.0.7",
     "request": "^2.63.0",
     "tmp": "^0.0.27",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "netrc" : "^0.1.3"
   },
   "devDependencies": {
     "connect": "^3.4.0",


### PR DESCRIPTION
This change modifies lib/defaults.js to read username and password from .netrc. Activated with the -n option.