### PR TITLE
remove -base-path option from deployproxy command. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,6 @@ for organization name, all of which are required.
 
 #### Optional parameters
 
-`--base-path -b`  
-(optional) The base path of the API proxy. For example, for this API proxy, the base path is /example-proxy: http://myorg-test.apigee.net/example-proxy/resource1.
-
 `--directory -d`  
 (optional) The path to the root directory of the API proxy on your local system. Will attempt to use current directory is none is specified.
 

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -18,7 +18,6 @@ var parseDeployments = require('./parsedeployments');
 var ProxyBase = 'apiproxy';
 var XmlExp = /(.+)\.xml$/i;
 var DeploymentDelay = 60;
-var BASE_PATH_REGEXP = /<BasePath[^>]*>(.*?)<\/BasePath>/;
 
 // By default, do not run NPM remotely
 var DefaultResolveModules = false;
@@ -38,10 +37,6 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Directory',
     shortOption: 'd',
     required: false
-  },
-  'base-path': {
-    name: 'Base Path',
-    shortOption: 'b'
   },
   'import-only': {
     name: 'Import Only',
@@ -82,9 +77,6 @@ module.exports.run = function(opts, cb) {
 
   // Run each function in series, and collect an array of results.
   async.series([
-    function(done) {
-      checkBasePath(opts, done);
-    },
     function(done) {
       getDeploymentInfo(opts, request, done);
     },
@@ -135,23 +127,6 @@ module.exports.run = function(opts, cb) {
         cb);
     });
 };
-
-function checkBasePath(opts, cb) {
-  if (!opts['base-path']) { return cb(); }
-  findProxies(opts, function(err, files) {
-    if (files.length !== 1) {
-      return cb(new Error('Cannot specify base-path option when more than one ProxyEndpoint'));
-    }
-    fs.readFile(files[0], 'utf8', function(err, data) {
-      if (err) { return cb(err); }
-      var match = data.match(BASE_PATH_REGEXP);
-      if (match && match[1] !== opts['base-path']) {
-        return cb(new Error(util.format('Cannot override ProxyEndpoint BasePath: %s', match[1])));
-      }
-      cb();
-    });
-  });
-}
 
 function getDeploymentInfo(opts, request, done) {
   // Find out if the root directory is a directory
@@ -616,13 +591,9 @@ function deployProxy(opts, request, done) {
 
     var uri = util.format('%s/v1/o/%s/e/%s/apis/%s/revisions/%d/deployments',
       opts.baseuri, opts.organization, environment, opts.api, opts.deploymentVersion);
-    if (opts.debug) { console.log('Going to POST to %s', uri); }
-
     var deployCmd = util.format('action=deploy&override=true&delay=%d', DeploymentDelay);
-    if (opts['base-path']) {
-      deployCmd = util.format('%s&basepath=%s', deployCmd, opts['base-path']);
-    }
-    if (opts.debug) { console.log('Going go send command %s', deployCmd); }
+
+    if (opts.debug) { console.log('Going to POST to %s\n              %s', uri, deployCmd); }
 
     request({
       uri: uri,


### PR DESCRIPTION
This option is not documented in the public API for Edge and ought not be used. I believe the implementation in the Edge Management server is incorrect. (There will soon be a Jira ticket for that in MGMT project).   Also, the option is unnecessary here, since the basepath is already specified in the proxyendpoint.  It is necessary in deploynodeapp, but not here. 