### PR TITLE
Several updates:  netrc, deployproxy -1 option, and --base-path option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ for organization name, all of which are required.
 
 #### Optional parameters
 
+`--base-path -b`  
+(optional) The base path of the API proxy. For example, for this API proxy, the base path is /example-proxy: http://myorg-test.apigee.net/example-proxy/resource1.
+
 `--directory -d`  
 (optional) The path to the root directory of the API proxy on your local system. Will attempt to use current directory is none is specified.
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,10 @@ for organization name, all of which are required.
 (optional) If the API proxy includes Node.js modules (e.g., in a `node_modules` directory), this option updates them on Apigee Edge without uploading them from your system. Basically, it's like running npm on Apigee Edge in the root directory of the API proxy bundle.  
 
 `--upload-modules    -U`  
-(optional) If specified, uploads Node.js modules from your system to Apigee Edge.
+(optional) If specified, uploads Node.js modules from your system to Apigee Edge. This is the default behavior.
+
+`--one-zip    -1`  
+(optional) If specified, imports the proxy bundle as one zip, rather than as several distinct zips. By default, not.
 
 ## <a name="undeploy"></a>undeploy
 

--- a/README.md
+++ b/README.md
@@ -174,9 +174,6 @@ for organization name, all of which are required.
 
 #### Optional parameters
 
-`--base-path -b`  
-(optional) The base path of the API proxy. For example, for this API proxy, the base path is /example-proxy: http://myorg-test.apigee.net/example-proxy/resource1.
-
 `--directory -d`  
 (optional) The path to the root directory of the API proxy on your local system. Will attempt to use current directory is none is specified.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Currently this only affects file uploads in the `deploynodeapp` command. Default
 `--username  -u`  
 (required) Your Apigee account username. May be set as an environment variable APIGEE_USERNAME.
 
-`--netrc  -n`  
+`--netrc  -N`  
 (optional) Use this in lieu of -u / -p, to tell apigeetool to retrieve credentials from your .netrc file.
 
 `--verbose   -V`  

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ for organization name, all of which are required.
 #### Optional parameters
 
 `--base-path -b`  
-(optional) The base path to use as a prefix for all proxy endpoints specified in the API proxy. For example, suppose you have an API Proxy with one ProxyEndpoint, and the BasePath for that ProxyEndpoint is /endpoint1.  If you then specify /test1/chris with this option, the ProxyEndpoint will be reachable at the effective path of /test/chris/abc.  The full URL for resource1 on that proxy endpoint might be http://myorg-test.apigee.net/test1/chris/endpoint1/resource1.
+(optional) The base path to use as a prefix for all proxy endpoints specified in the API proxy. For example, suppose you have an API Proxy with one ProxyEndpoint, and the BasePath for that ProxyEndpoint is /endpoint1.  If you then specify /test1/chris with this option, the ProxyEndpoint will be reachable at the effective path of /test1/chris/abc.  The full URL for resource1 on that proxy endpoint might be http://myorg-test.apigee.net/test1/chris/endpoint1/resource1.
 
 `--directory -d`  
 (optional) The path to the root directory of the API proxy on your local system. Will attempt to use current directory is none is specified.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ for organization name, all of which are required.
 #### Optional parameters
 
 `--base-path -b`  
-(optional) The base path of the API proxy. For example, for this API proxy, the base path is /example-proxy: http://myorg-test.apigee.net/example-proxy/resource1.
+(optional) The base path to use as a prefix for all proxy endpoints specified in the API proxy. For example, suppose you have an API Proxy with one ProxyEndpoint, and the BasePath for that ProxyEndpoint is /endpoint1.  If you then specify /test1/chris with this option, the ProxyEndpoint will be reachable at the effective path of /test/chris/abc.  The full URL for resource1 on that proxy endpoint might be http://myorg-test.apigee.net/test1/chris/endpoint1/resource1.
 
 `--directory -d`  
 (optional) The path to the root directory of the API proxy on your local system. Will attempt to use current directory is none is specified.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ for organization name, all of which are required.
 #### Optional parameters
 
 `--base-path -b`  
-(optional) The base path to use as a prefix for all proxy endpoints specified in the API proxy. For example, suppose you have an API Proxy with one ProxyEndpoint, and the BasePath for that ProxyEndpoint is /endpoint1.  If you then specify /test1/chris with this option, the ProxyEndpoint will be reachable at the effective path of /test1/chris/abc.  The full URL for resource1 on that proxy endpoint might be http://myorg-test.apigee.net/test1/chris/endpoint1/resource1.
+(optional) The base path to use as a prefix for all proxy endpoints specified in the API proxy. For example, suppose you have an API Proxy with one ProxyEndpoint, and the BasePath for that ProxyEndpoint is /endpoint1.  If you then specify /test1/chris with this option, the ProxyEndpoint will be reachable at the effective path of /test1/chris/endpoint1.  The full URL for resource1 on that proxy endpoint might be http://myorg-test.apigee.net/test1/chris/endpoint1/resource1.
 
 `--directory -d`  
 (optional) The path to the root directory of the API proxy on your local system. Will attempt to use current directory is none is specified.

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -83,9 +83,6 @@ module.exports.run = function(opts, cb) {
   // Run each function in series, and collect an array of results.
   async.series([
     function(done) {
-      checkBasePath(opts, done);
-    },
-    function(done) {
       getDeploymentInfo(opts, request, done);
     },
     function(done) {
@@ -135,23 +132,6 @@ module.exports.run = function(opts, cb) {
         cb);
     });
 };
-
-function checkBasePath(opts, cb) {
-  if (!opts['base-path']) { return cb(); }
-  findProxies(opts, function(err, files) {
-    if (files.length !== 1) {
-      return cb(new Error('Cannot specify base-path option when more than one ProxyEndpoint'));
-    }
-    fs.readFile(files[0], 'utf8', function(err, data) {
-      if (err) { return cb(err); }
-      var match = data.match(BASE_PATH_REGEXP);
-      if (match && match[1] !== opts['base-path']) {
-        return cb(new Error(util.format('Cannot override ProxyEndpoint BasePath: %s', match[1])));
-      }
-      cb();
-    });
-  });
-}
 
 function getDeploymentInfo(opts, request, done) {
   // Find out if the root directory is a directory
@@ -616,13 +596,11 @@ function deployProxy(opts, request, done) {
 
     var uri = util.format('%s/v1/o/%s/e/%s/apis/%s/revisions/%d/deployments',
       opts.baseuri, opts.organization, environment, opts.api, opts.deploymentVersion);
-    if (opts.debug) { console.log('Going to POST to %s', uri); }
-
     var deployCmd = util.format('action=deploy&override=true&delay=%d', DeploymentDelay);
     if (opts['base-path']) {
       deployCmd = util.format('%s&basepath=%s', deployCmd, opts['base-path']);
     }
-    if (opts.debug) { console.log('Going go send command %s', deployCmd); }
+    if (opts.debug) { console.log('Going to POST to %s\n        command: %s', uri, deployCmd); }
 
     request({
       uri: uri,

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -22,6 +22,7 @@ var BASE_PATH_REGEXP = /<BasePath[^>]*>(.*?)<\/BasePath>/;
 
 // By default, do not run NPM remotely
 var DefaultResolveModules = false;
+var DefaultOneZip = false;
 
 var descriptor = defaults.defaultDescriptor({
   api: {
@@ -57,6 +58,11 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Upload Modules',
     shortOption: 'U',
     toggle: true
+  },
+  'one-zip': {
+    name: 'One Zip',
+    shortOption: '1',
+    toggle: true
   }
 });
 module.exports.descriptor = descriptor;
@@ -88,18 +94,18 @@ module.exports.run = function(opts, cb) {
     function(done) {
       importApiProxyBundle(opts, request, done);
     },
-    // function(done) {
-    //   uploadResources(opts, request, done);
-    // },
-    // function(done) {
-    //   uploadPolicies(opts, request, done);
-    // },
-    // function(done) {
-    //   uploadTargets(opts, request, done);
-    // },
-    // function(done) {
-    //   uploadProxies(opts, request, done);
-    // },
+    function(done) {
+      uploadResources(opts, request, done);
+    },
+    function(done) {
+      uploadPolicies(opts, request, done);
+    },
+    function(done) {
+      uploadTargets(opts, request, done);
+    },
+    function(done) {
+      uploadProxies(opts, request, done);
+    },
     function(done) {
       runNpm(opts, request, done);
     },
@@ -210,33 +216,56 @@ function makeFilterFn(opts) {
 }
 
 function importApiProxyBundle(opts, request, done) {
-  // Check for a single XML file in the bundle root directory. If not, error.
+  // toggle the behavior to upload the proxy as a single zip
+  opts.oneZip = DefaultOneZip;
+  if (opts['one-zip'] && (opts['one-zip'] === true)) {
+    opts.oneZip = true;
+  }
+  var rootDoc;
+  var rootEntryName;
+
+  // Check for a single XML file in the bundle root directory. If not, deal with it.
   var pd = path.join(opts.directory, ProxyBase);
   var topXmlFiles = fsutils.readdirSyncFilesOnly(pd)
     .filter(function(item){ return item.endsWith('.xml'); });
   if (topXmlFiles.length === 1) {
+    var fn = path.join(pd, topXmlFiles[0]);
     if (opts.verbose) {
-      var fn = path.join(pd, topXmlFiles[0]);
       console.log('Using %s as the root file', fn);
     }
+    if ( ! opts.oneZip) {
+      rootEntryName = topXmlFiles[0];
+      rootDoc = fs.readFileSync(fn);
+    }
+  }
+  else if ( ! opts.oneZip) {
+    rootEntryName = opts.api + '.xml';
+    rootDoc = mustache.render('<APIProxy name="{{api}}"/>', opts);
   }
   else {
     if (opts.verbose) {
-      console.error('Proxy directory appears to be invalid. Too many XML files.');
+      console.error('Proxy directory appears to be invalid. Expected 1 XML file, found %d.',
+                    topXmlFiles.length);
     }
-    done(new Error('Proxy import failed. Too many XML files.'));
+    return done(new Error(util.format('Proxy import failed. Expected to find a single XML file; found %d.',
+                               topXmlFiles.length)));
   }
 
-  var uri = util.format('%s/v1/o/%s/apis?action=import&validate=true&name=%s',
-                    opts.baseuri, opts.organization, opts.api);
   if (opts.verbose) {
     console.log('Creating revision %d of API %s', opts.deploymentVersion, opts.api);
   }
 
-  // zip and import an entire directory.
-  // ensure to zip node_modules directory only when needed.
-  ziputils.zipDirectoryFiltered(pd, ProxyBase, makeFilterFn(opts), function(error, zipBuf) {
-    if (error) { done(error); }
+  // Either:
+  // A. zip and import an entire directory; ensure to zip node_modules directory only when needed.
+  // or,
+  // B. zip one file, so that we can import in pieces.
+
+  var zipFunc = (opts.oneZip) ?
+    function(cb) { ziputils.zipDirectoryFiltered(pd, ProxyBase, makeFilterFn(opts), cb); } :
+  function(cb) {var buf = ziputils.makeOneFileZip(ProxyBase, rootEntryName, rootDoc); cb(null, buf);};
+
+  zipFunc(function(error, zipBuf) {
+    if (error) { return done(error); }
     // For debugging
     if (opts.debug) {
       var zipname = '/tmp/' + opts.api + '-' + (new Date()).toISOString()
@@ -246,6 +275,8 @@ function importApiProxyBundle(opts, request, done) {
       fs.writeFileSync(zipname, zipBuf);
       console.log('find zipfile in %s', zipname);
     }
+    var uri = util.format('%s/v1/o/%s/apis?action=import&validate=%s&name=%s',
+                          opts.baseuri, opts.organization, (opts.oneZip)?'true':'false', opts.api);
     if (opts.debug) {
       console.log('Calling %s', uri);
     }
@@ -260,6 +291,7 @@ function importApiProxyBundle(opts, request, done) {
     });
   });
 }
+
 
 function proxyCreationDone(err, req, body, opts, done) {
   if (err) {
@@ -278,294 +310,313 @@ function proxyCreationDone(err, req, body, opts, done) {
   }
 }
 
-// function uploadResources(opts, request, done) {
-//   var resBaseDir = path.join(opts.directory, ProxyBase, 'resources');
-//   // Produce a list of entries to either ZIP or upload.
-//   var entries;
-//   try {
-//     entries = ziputils.enumerateResourceDirectory(resBaseDir, opts.remoteNpm);
-//     if (opts.debug) {
-//       console.log('Found %d resources in that proxy', entries.length);
-//     }
-//   } catch (e) {
-//     if (e.code === 'ENOENT') {
-//       if (opts.verbose) {
-//         console.error('No resources found');
-//       }
-//       done();
-//     } else {
-//       done(e);
-//     }
-//     return;
-//   }
-//
-//   async.eachLimit(entries, opts.asyncLimit, function(entry, entryDone) {
-//     var uri =
-//       util.format('%s/v1/o/%s/apis/%s/revisions/%d/resources?type=%s&name=%s',
-//                   opts.baseuri, opts.organization, opts.api,
-//                   opts.deploymentVersion, entry.resourceType, entry.resourceName);
-//     if (entry.directory) {
-//       // ZIP up all directories, possibly with additional file prefixes
-//       ziputils.zipDirectory(entry.fileName, entry.zipEntryName, function(err, zipBuf) {
-//         if (err) {
-//           entryDone(err);
-//         } else {
-//           if (opts.verbose) {
-//             console.log('Uploading %s resource %s', entry.resourceType, entry.resourceName);
-//           }
-//           request({
-//             uri: uri,
-//             method: 'POST',
-//             json: false,
-//             headers: { 'Content-Type': 'application/octet-stream' },
-//             body: zipBuf
-//           }, function(err, req, body) {
-//             handleUploadResult(err, req, entryDone);
-//           });
-//         }
-//       });
-//
-//     } else {
-//       if (opts.verbose) {
-//         console.log('Uploading %s resource %s', entry.resourceType, entry.resourceName);
-//       }
-//       var httpReq = request({
-//         uri: uri,
-//         method: 'POST',
-//         json: false,
-//         headers: { 'Content-Type': 'application/octet-stream' }
-//       }, function(err, req, body) {
-//         handleUploadResult(err, req, entryDone);
-//       });
-//
-//       var fileStream = fs.createReadStream(entry.fileName);
-//       fileStream.pipe(httpReq);
-//     }
-//   }, function(err) {
-//     done(err);
-//   });
-// }
+function uploadResources(opts, request, done) {
+  if (opts.oneZip) {
+    done();
+  }
+  else {
+    var resBaseDir = path.join(opts.directory, ProxyBase, 'resources');
+    // Produce a list of entries to either ZIP or upload.
+    var entries;
+    try {
+      entries = ziputils.enumerateResourceDirectory(resBaseDir, opts.remoteNpm);
+      if (opts.debug) {
+        console.log('Found %d resources in that proxy', entries.length);
+      }
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        if (opts.verbose) {
+          console.error('No resources found');
+        }
+        done();
+      } else {
+        done(e);
+      }
+      return;
+    }
 
-// function handleUploadResult(err, req, itemDone) {
-//   if (err) {
-//     itemDone(err);
-//   } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
-//     itemDone();
-//   } else {
-//     itemDone(new Error(util.format('Error uploading resource: %d',
-//       req.statusCode)));
-//   }
-// }
-//
-// function uploadPolicies(opts, request, done) {
-//   var baseDir = path.join(opts.directory, ProxyBase, 'policies');
-//   var fileNames;
-//   try {
-//     fileNames = fs.readdirSync(baseDir);
-//   } catch (e) {
-//     if (e.code === 'ENOENT') {
-//       if (opts.verbose) {
-//         console.log('No policies found');
-//       }
-//       done();
-//     } else {
-//       done(e);
-//     }
-//     return;
-//   }
-//
-//   async.eachLimit(fileNames, opts.asyncLimit, function(fileName, itemDone) {
-//     var rp = path.join(baseDir, fileName);
-//     var stat = fs.statSync(rp);
-//     if (!XmlExp.test(fileName)) {
-//       if (opts.verbose) {
-//         console.log('Skipping file %s which is not an XML file', rp);
-//       }
-//       return itemDone();
-//     }
-//     if (!stat.isFile()) {
-//       if (opts.verbose) {
-//         console.log('Skipping file %s which is not a regular file', rp);
-//       }
-//       return itemDone();
-//     }
-//
-//     if (opts.verbose) {
-//       console.log('Uploading policy %s', fileName);
-//     }
-//     var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/policies',
-//                 opts.baseuri, opts.organization, opts.api,
-//                 opts.deploymentVersion);
-//     var postReq = request({
-//       uri: uri,
-//       headers: { 'Content-Type': 'application/xml' },
-//       json: false,
-//       method: 'POST'
-//     }, function(err, req, body) {
-//       if (err) {
-//         itemDone(err);
-//       } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
-//         itemDone();
-//       } else {
-//         itemDone(new Error(util.format('Error uploading policy: %s',
-//           req.statusCode)));
-//       }
-//     });
-//
-//     var rf = fs.createReadStream(rp);
-//     rf.pipe(postReq);
-//
-//   }, function(err) {
-//     done(err);
-//   });
-// }
-//
-// function uploadTargets(opts, request, done) {
-//   var baseDir = path.join(opts.directory, ProxyBase, 'targets');
-//   var fileNames;
-//   try {
-//     fileNames = fs.readdirSync(baseDir);
-//   } catch (e) {
-//     if (e.code === 'ENOENT') {
-//       if (opts.verbose) {
-//         console.log('No targets found');
-//       }
-//       done();
-//     } else {
-//       done(e);
-//     }
-//     return;
-//   }
-//
-//   async.eachLimit(fileNames, opts.asyncLimit, function(fileName, itemDone) {
-//     var rp = path.join(baseDir, fileName);
-//     var stat = fs.statSync(rp);
-//     var isXml = XmlExp.exec(fileName);
-//     if (!isXml) {
-//       if (opts.verbose) {
-//         console.log('Skipping file %s which is not an XML file', rp);
-//       }
-//       return itemDone();
-//     }
-//     if (!stat.isFile()) {
-//       if (opts.verbose) {
-//         console.log('Skipping file %s which is not a regular file', rp);
-//       }
-//       return itemDone();
-//     }
-//
-//     if (opts.verbose) {
-//       console.log('Uploading target %s', isXml[1]);
-//     }
-//     var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/targets?name=%s',
-//                 opts.baseuri, opts.organization, opts.api,
-//                 opts.deploymentVersion, isXml[1]);
-//     var postReq = request({
-//       uri: uri,
-//       headers: { 'Content-Type': 'application/xml' },
-//       json: false,
-//       method: 'POST'
-//     }, function(err, req, body) {
-//       if (err) {
-//         itemDone(err);
-//       } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
-//         itemDone();
-//       } else {
-//         itemDone(new Error(util.format('Error uploading target: %s',
-//           req.statusCode)));
-//       }
-//     });
-//
-//     var rf = fs.createReadStream(rp);
-//     rf.pipe(postReq);
-//
-//   }, function(err) {
-//     done(err);
-//   });
-// }
-//
-//
-// function findProxies(opts, cb) {
-//   var baseDir = path.join(opts.directory, ProxyBase, 'proxies');
-//   var fileNames;
-//   try {
-//     fileNames = fs.readdirSync(baseDir);
-//   } catch (e) {
-//     if (e.code === 'ENOENT') {
-//       if (opts.verbose) { console.log('No proxies found'); }
-//       cb();
-//     } else {
-//       cb(e);
-//     }
-//     return;
-//   }
-//
-//   var files = _.map(fileNames,
-//     function(fileName) {
-//       var rp = path.join(baseDir, fileName);
-//       var isXml = XmlExp.exec(fileName);
-//       if (!isXml) {
-//         if (opts.verbose) { console.log('Skipping file %s which is not an XML file', rp); }
-//         return false;
-//       }
-//       var stat = fs.statSync(rp);
-//       if (!stat.isFile()) {
-//         if (opts.verbose) { console.log('Skipping file %s which is not a regular file', rp); }
-//         return false;
-//       }
-//       return rp;
-//     });
-//   cb(null, _.compact(files));
-// }
+    async.eachLimit(entries, opts.asynclimit, function(entry, entryDone) {
+      var uri =
+        util.format('%s/v1/o/%s/apis/%s/revisions/%d/resources?type=%s&name=%s',
+                    opts.baseuri, opts.organization, opts.api,
+                    opts.deploymentVersion, entry.resourceType, entry.resourceName);
+      if (entry.directory) {
+        // ZIP up all directories, possibly with additional file prefixes
+        ziputils.zipDirectory(entry.fileName, entry.zipEntryName, function(err, zipBuf) {
+          if (err) {
+            entryDone(err);
+          } else {
+            if (opts.verbose) {
+              console.log('Uploading %s resource %s', entry.resourceType, entry.resourceName);
+            }
+            request({
+              uri: uri,
+              method: 'POST',
+              json: false,
+              headers: { 'Content-Type': 'application/octet-stream' },
+              body: zipBuf
+            }, function(err, req, body) {
+              handleUploadResult(err, req, entryDone);
+            });
+          }
+        });
 
-// function uploadProxies(opts, request, done) {
-//
-//   findProxies(opts, function(err, filePaths) {
-//     if (err) { return done(err); }
-//
-//     async.eachLimit(filePaths, opts.asyncLimit, function(filePath, itemDone) {
-//
-//       var proxyName = filePath.split(path.sep).pop().split('.')[0];
-//       if (opts.verbose) {
-//         console.log('Uploading proxy %s', proxyName);
-//       }
-//       var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/proxies?name=%s',
-//         opts.baseuri, opts.organization, opts.api,
-//         opts.deploymentVersion, proxyName);
-//       var postReq = request({
-//         uri: uri,
-//         headers: { 'Content-Type': 'application/xml' },
-//         json: false,
-//         method: 'POST'
-//       }, function(err, req, body) {
-//         if (err) {
-//           itemDone(err);
-//         } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
-//           itemDone();
-//         } else {
-//           if (opts.verbose) {
-//             console.error('Deployment result: %j', body);
-//           }
-//           var jsonBody = JSON.parse(body);
-//           var errMsg;
-//           if (jsonBody && (jsonBody.message)) {
-//             errMsg = jsonBody.message;
-//           } else {
-//             errMsg = util.format('Error uploading proxy: %d',
-//               req.statusCode);
-//           }
-//           itemDone(new Error(errMsg));
-//         }
-//       });
-//
-//       var rf = fs.createReadStream(filePath);
-//       rf.pipe(postReq);
-//
-//     }, function(err) {
-//       done(err);
-//     });
-//   });
-// }
+      } else {
+        if (opts.verbose) {
+          console.log('Uploading %s resource %s', entry.resourceType, entry.resourceName);
+        }
+        var httpReq = request({
+              uri: uri,
+              method: 'POST',
+              json: false,
+              headers: { 'Content-Type': 'application/octet-stream' }
+            }, function(err, req, body) {
+              handleUploadResult(err, req, entryDone);
+            });
+
+        var fileStream = fs.createReadStream(entry.fileName);
+        fileStream.pipe(httpReq);
+      }
+    }, function(err) {
+      done(err);
+    });
+  }
+}
+
+function handleUploadResult(err, req, itemDone) {
+  if (err) {
+    itemDone(err);
+  } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
+    itemDone();
+  } else {
+    itemDone(new Error(util.format('Error uploading resource: %d',
+      req.statusCode)));
+  }
+}
+
+function uploadPolicies(opts, request, done) {
+  if (opts.oneZip) {
+    done();
+  }
+  else {
+    var baseDir = path.join(opts.directory, ProxyBase, 'policies');
+    var fileNames;
+    try {
+      fileNames = fs.readdirSync(baseDir);
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        if (opts.verbose) {
+          console.log('No policies found');
+        }
+        done();
+      } else {
+        done(e);
+      }
+      return;
+    }
+
+    async.eachLimit(fileNames, opts.asynclimit, function(fileName, itemDone) {
+      var rp = path.join(baseDir, fileName);
+      var stat = fs.statSync(rp);
+      if (!XmlExp.test(fileName)) {
+        if (opts.verbose) {
+          console.log('Skipping file %s which is not an XML file', rp);
+        }
+        return itemDone();
+      }
+      if (!stat.isFile()) {
+        if (opts.verbose) {
+          console.log('Skipping file %s which is not a regular file', rp);
+        }
+        return itemDone();
+      }
+
+      if (opts.verbose) {
+        console.log('Uploading policy %s', fileName);
+      }
+      var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/policies',
+                            opts.baseuri, opts.organization, opts.api,
+                            opts.deploymentVersion);
+      var postReq = request({
+            uri: uri,
+            headers: { 'Content-Type': 'application/xml' },
+            json: false,
+            method: 'POST'
+          }, function(err, req, body) {
+            if (err) {
+              itemDone(err);
+            } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
+              itemDone();
+            } else {
+              itemDone(new Error(util.format('Error uploading policy: %s',
+                                             req.statusCode)));
+            }
+          });
+
+      var rf = fs.createReadStream(rp);
+      rf.pipe(postReq);
+
+    }, function(err) {
+      done(err);
+    });
+  }
+}
+
+function uploadTargets(opts, request, done) {
+  if (opts.oneZip) {
+    done();
+  }
+  else {
+    var baseDir = path.join(opts.directory, ProxyBase, 'targets');
+    var fileNames;
+    try {
+      fileNames = fs.readdirSync(baseDir);
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        if (opts.verbose) {
+          console.log('No targets found');
+        }
+        done();
+      } else {
+        done(e);
+      }
+      return;
+    }
+
+    async.eachLimit(fileNames, opts.asynclimit, function(fileName, itemDone) {
+      var rp = path.join(baseDir, fileName);
+      var stat = fs.statSync(rp);
+      var isXml = XmlExp.exec(fileName);
+      if (!isXml) {
+        if (opts.verbose) {
+          console.log('Skipping file %s which is not an XML file', rp);
+        }
+        return itemDone();
+      }
+      if (!stat.isFile()) {
+        if (opts.verbose) {
+          console.log('Skipping file %s which is not a regular file', rp);
+        }
+        return itemDone();
+      }
+
+      if (opts.verbose) {
+        console.log('Uploading target %s', isXml[1]);
+      }
+      var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/targets?name=%s',
+                            opts.baseuri, opts.organization, opts.api,
+                            opts.deploymentVersion, isXml[1]);
+      var postReq = request({
+            uri: uri,
+            headers: { 'Content-Type': 'application/xml' },
+            json: false,
+            method: 'POST'
+          }, function(err, req, body) {
+            if (err) {
+              itemDone(err);
+            } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
+              itemDone();
+            } else {
+              itemDone(new Error(util.format('Error uploading target: %s',
+                                             req.statusCode)));
+            }
+          });
+
+      var rf = fs.createReadStream(rp);
+      rf.pipe(postReq);
+
+    }, function(err) {
+      done(err);
+    });
+  }
+}
+
+function findProxies(opts, cb) {
+  var baseDir = path.join(opts.directory, ProxyBase, 'proxies');
+  var fileNames;
+  try {
+    fileNames = fs.readdirSync(baseDir);
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      if (opts.verbose) { console.log('No proxies found'); }
+      cb();
+    } else {
+      cb(e);
+    }
+    return;
+  }
+
+  var files = _.map(fileNames,
+    function(fileName) {
+      var rp = path.join(baseDir, fileName);
+      var isXml = XmlExp.exec(fileName);
+      if (!isXml) {
+        if (opts.verbose) { console.log('Skipping file %s which is not an XML file', rp); }
+        return false;
+      }
+      var stat = fs.statSync(rp);
+      if (!stat.isFile()) {
+        if (opts.verbose) { console.log('Skipping file %s which is not a regular file', rp); }
+        return false;
+      }
+      return rp;
+    });
+  cb(null, _.compact(files));
+}
+
+function uploadProxies(opts, request, done) {
+  if (opts.oneZip) {
+    done();
+  }
+  else {
+
+    findProxies(opts, function(err, filePaths) {
+      if (err) { return done(err); }
+
+      async.eachLimit(filePaths, opts.asynclimit, function(filePath, itemDone) {
+
+        var proxyName = filePath.split(path.sep).pop().split('.')[0];
+        if (opts.verbose) {
+          console.log('Uploading proxy %s', proxyName);
+        }
+        var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/proxies?name=%s',
+                              opts.baseuri, opts.organization, opts.api,
+                              opts.deploymentVersion, proxyName);
+        var postReq = request({
+              uri: uri,
+              headers: { 'Content-Type': 'application/xml' },
+              json: false,
+              method: 'POST'
+            }, function(err, req, body) {
+              if (err) {
+                itemDone(err);
+              } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
+                itemDone();
+              } else {
+                if (opts.verbose) {
+                  console.error('Deployment result: %j', body);
+                }
+                var jsonBody = JSON.parse(body);
+                var errMsg;
+                if (jsonBody && (jsonBody.message)) {
+                  errMsg = jsonBody.message;
+                } else {
+                  errMsg = util.format('Error uploading proxy: %d',
+                                       req.statusCode);
+                }
+                itemDone(new Error(errMsg));
+              }
+            });
+
+        var rf = fs.createReadStream(filePath);
+        rf.pipe(postReq);
+
+      }, function(err) {
+        done(err);
+      });
+    });
+  }
+}
 
 function runNpm(opts, request, done) {
   if (!opts.remoteNpm) {

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -18,6 +18,7 @@ var parseDeployments = require('./parsedeployments');
 var ProxyBase = 'apiproxy';
 var XmlExp = /(.+)\.xml$/i;
 var DeploymentDelay = 60;
+var BASE_PATH_REGEXP = /<BasePath[^>]*>(.*?)<\/BasePath>/;
 
 // By default, do not run NPM remotely
 var DefaultResolveModules = false;
@@ -37,6 +38,10 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Directory',
     shortOption: 'd',
     required: false
+  },
+  'base-path': {
+    name: 'Base Path',
+    shortOption: 'b'
   },
   'import-only': {
     name: 'Import Only',
@@ -77,6 +82,9 @@ module.exports.run = function(opts, cb) {
 
   // Run each function in series, and collect an array of results.
   async.series([
+    function(done) {
+      checkBasePath(opts, done);
+    },
     function(done) {
       getDeploymentInfo(opts, request, done);
     },
@@ -127,6 +135,23 @@ module.exports.run = function(opts, cb) {
         cb);
     });
 };
+
+function checkBasePath(opts, cb) {
+  if (!opts['base-path']) { return cb(); }
+  findProxies(opts, function(err, files) {
+    if (files.length !== 1) {
+      return cb(new Error('Cannot specify base-path option when more than one ProxyEndpoint'));
+    }
+    fs.readFile(files[0], 'utf8', function(err, data) {
+      if (err) { return cb(err); }
+      var match = data.match(BASE_PATH_REGEXP);
+      if (match && match[1] !== opts['base-path']) {
+        return cb(new Error(util.format('Cannot override ProxyEndpoint BasePath: %s', match[1])));
+      }
+      cb();
+    });
+  });
+}
 
 function getDeploymentInfo(opts, request, done) {
   // Find out if the root directory is a directory
@@ -591,9 +616,13 @@ function deployProxy(opts, request, done) {
 
     var uri = util.format('%s/v1/o/%s/e/%s/apis/%s/revisions/%d/deployments',
       opts.baseuri, opts.organization, environment, opts.api, opts.deploymentVersion);
-    var deployCmd = util.format('action=deploy&override=true&delay=%d', DeploymentDelay);
+    if (opts.debug) { console.log('Going to POST to %s', uri); }
 
-    if (opts.debug) { console.log('Going to POST to %s\n              %s', uri, deployCmd); }
+    var deployCmd = util.format('action=deploy&override=true&delay=%d', DeploymentDelay);
+    if (opts['base-path']) {
+      deployCmd = util.format('%s&basepath=%s', deployCmd, opts['base-path']);
+    }
+    if (opts.debug) { console.log('Going go send command %s', deployCmd); }
 
     request({
       uri: uri,

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -86,20 +86,20 @@ module.exports.run = function(opts, cb) {
       getDeploymentInfo(opts, request, done);
     },
     function(done) {
-      createApiProxy(opts, request, done);
+      importApiProxyBundle(opts, request, done);
     },
-    function(done) {
-      uploadResources(opts, request, done);
-    },
-    function(done) {
-      uploadPolicies(opts, request, done);
-    },
-    function(done) {
-      uploadTargets(opts, request, done);
-    },
-    function(done) {
-      uploadProxies(opts, request, done);
-    },
+    // function(done) {
+    //   uploadResources(opts, request, done);
+    // },
+    // function(done) {
+    //   uploadPolicies(opts, request, done);
+    // },
+    // function(done) {
+    //   uploadTargets(opts, request, done);
+    // },
+    // function(done) {
+    //   uploadProxies(opts, request, done);
+    // },
     function(done) {
       runNpm(opts, request, done);
     },
@@ -178,7 +178,7 @@ function getDeploymentInfo(opts, request, done) {
       } else if (req.statusCode === 200) {
         opts.deploymentVersion =
           parseInt(_.max(body.revision, function(r) { return parseInt(r); })) + 1;
-        if (opts.verbose) {
+        if (opts.verbose || opts.debug) {
           console.log('Going to create revision %d of API %s',
                       opts.deploymentVersion, opts.api);
         }
@@ -189,47 +189,75 @@ function getDeploymentInfo(opts, request, done) {
   });
 }
 
-function createApiProxy(opts, request, done) {
-  // Is there a single XML file in the root directory?
-  // If not, then create one
-  var rootDoc;
-  var rootEntryName;
 
+function makeFilterFn(opts) {
+  return function(fullname) {
+    var basename = path.basename(fullname);
+    var result = basename !== '.DS_Store' &&
+      basename !== '.git' &&
+      !basename.endsWith('~') && // emacs backup files
+      !(basename.endsWith('#') && basename.startsWith('#')) && // emacs temp files
+      basename !== 'Icon\r'; // googledrive Icon\015 file
+    if (opts.remoteNpm) {
+      result &= (basename !== 'node_modules' &&
+        basename !== 'node_modules.zip');
+    }
+    if (opts.debug) {
+      console.log('filterFn %s ==> %s', fullname, result);
+    }
+    return result;
+  };
+}
+
+function importApiProxyBundle(opts, request, done) {
+  // Check for a single XML file in the bundle root directory. If not, error.
   var pd = path.join(opts.directory, ProxyBase);
-  var topFiles = fsutils.readdirSyncFilesOnly(pd);
-  if (topFiles.length === 1) {
-    var fn = path.join(pd, topFiles[0]);
-    rootEntryName = topFiles[0];
+  var topXmlFiles = fsutils.readdirSyncFilesOnly(pd)
+    .filter(function(item){ return item.endsWith('.xml'); });
+  if (topXmlFiles.length === 1) {
     if (opts.verbose) {
+      var fn = path.join(pd, topXmlFiles[0]);
       console.log('Using %s as the root file', fn);
     }
-    rootDoc = fs.readFileSync(fn);
-  } else {
-    rootEntryName = opts.api + '.xml';
-    rootDoc = mustache.render('<APIProxy name="{{api}}"/>', opts);
+  }
+  else {
+    if (opts.verbose) {
+      console.error('Proxy directory appears to be invalid. Too many XML files.');
+    }
+    done(new Error('Proxy import failed. Too many XML files.'));
   }
 
-  var uri = util.format('%s/v1/o/%s/apis?action=import&validate=false&name=%s',
+  var uri = util.format('%s/v1/o/%s/apis?action=import&validate=true&name=%s',
                     opts.baseuri, opts.organization, opts.api);
-  if (opts.debug) {
-    console.log('Calling %s', uri);
-  }
   if (opts.verbose) {
-    console.log('Creating revision %d of API %s', opts.deploymentVersion,
-               opts.api);
+    console.log('Creating revision %d of API %s', opts.deploymentVersion, opts.api);
   }
-  // The only way to do this is to import a ZIP. What fun.
-  var zipBuf = ziputils.makeOneFileZip(ProxyBase, rootEntryName, rootDoc);
-  // For debugging
-  //fs.writeFileSync('./test.zip', zipBuf);
-  request({
-    uri: uri,
-    headers: { 'Content-Type': 'application/octet-stream' },
-    json: false,
-    method: 'POST',
-    body: zipBuf
-  }, function(err, req, body) {
-    proxyCreationDone(err, req, body, opts, done);
+
+  // zip and import an entire directory.
+  // ensure to zip node_modules directory only when needed.
+  ziputils.zipDirectoryFiltered(pd, ProxyBase, makeFilterFn(opts), function(error, zipBuf) {
+    if (error) { done(error); }
+    // For debugging
+    if (opts.debug) {
+      var zipname = '/tmp/' + opts.api + '-' + (new Date()).toISOString()
+        .replace(new RegExp('[-\\.Z:]','g'), '')
+        .replace(new RegExp('T'),'') +
+        '.zip';
+      fs.writeFileSync(zipname, zipBuf);
+      console.log('find zipfile in %s', zipname);
+    }
+    if (opts.debug) {
+      console.log('Calling %s', uri);
+    }
+    request({
+      uri: uri,
+      headers: { 'Content-Type': 'application/octet-stream' },
+      json: false,
+      method: 'POST',
+      body: zipBuf
+    }, function(err, req, body) {
+      proxyCreationDone(err, req, body, opts, done);
+    });
   });
 }
 
@@ -237,6 +265,9 @@ function proxyCreationDone(err, req, body, opts, done) {
   if (err) {
     done(err);
   } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
+    if (opts.verbose) {
+      console.log('Proxy creation done');
+    }
     done();
   } else {
     if (opts.verbose) {
@@ -247,290 +278,294 @@ function proxyCreationDone(err, req, body, opts, done) {
   }
 }
 
-function uploadResources(opts, request, done) {
-  var resBaseDir = path.join(opts.directory, ProxyBase, 'resources');
-  // Produce a list of entries to either ZIP or upload.
-  var entries;
-  try {
-    entries = ziputils.enumerateResourceDirectory(resBaseDir, opts.remoteNpm);
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      if (opts.verbose) {
-        console.error('No resources found');
-      }
-      done();
-    } else {
-      done(e);
-    }
-    return;
-  }
+// function uploadResources(opts, request, done) {
+//   var resBaseDir = path.join(opts.directory, ProxyBase, 'resources');
+//   // Produce a list of entries to either ZIP or upload.
+//   var entries;
+//   try {
+//     entries = ziputils.enumerateResourceDirectory(resBaseDir, opts.remoteNpm);
+//     if (opts.debug) {
+//       console.log('Found %d resources in that proxy', entries.length);
+//     }
+//   } catch (e) {
+//     if (e.code === 'ENOENT') {
+//       if (opts.verbose) {
+//         console.error('No resources found');
+//       }
+//       done();
+//     } else {
+//       done(e);
+//     }
+//     return;
+//   }
+//
+//   async.eachLimit(entries, opts.asyncLimit, function(entry, entryDone) {
+//     var uri =
+//       util.format('%s/v1/o/%s/apis/%s/revisions/%d/resources?type=%s&name=%s',
+//                   opts.baseuri, opts.organization, opts.api,
+//                   opts.deploymentVersion, entry.resourceType, entry.resourceName);
+//     if (entry.directory) {
+//       // ZIP up all directories, possibly with additional file prefixes
+//       ziputils.zipDirectory(entry.fileName, entry.zipEntryName, function(err, zipBuf) {
+//         if (err) {
+//           entryDone(err);
+//         } else {
+//           if (opts.verbose) {
+//             console.log('Uploading %s resource %s', entry.resourceType, entry.resourceName);
+//           }
+//           request({
+//             uri: uri,
+//             method: 'POST',
+//             json: false,
+//             headers: { 'Content-Type': 'application/octet-stream' },
+//             body: zipBuf
+//           }, function(err, req, body) {
+//             handleUploadResult(err, req, entryDone);
+//           });
+//         }
+//       });
+//
+//     } else {
+//       if (opts.verbose) {
+//         console.log('Uploading %s resource %s', entry.resourceType, entry.resourceName);
+//       }
+//       var httpReq = request({
+//         uri: uri,
+//         method: 'POST',
+//         json: false,
+//         headers: { 'Content-Type': 'application/octet-stream' }
+//       }, function(err, req, body) {
+//         handleUploadResult(err, req, entryDone);
+//       });
+//
+//       var fileStream = fs.createReadStream(entry.fileName);
+//       fileStream.pipe(httpReq);
+//     }
+//   }, function(err) {
+//     done(err);
+//   });
+// }
 
-  async.eachLimit(entries, opts.asyncLimit, function(entry, entryDone) {
-    var uri =
-      util.format('%s/v1/o/%s/apis/%s/revisions/%d/resources?type=%s&name=%s',
-                  opts.baseuri, opts.organization, opts.api,
-                  opts.deploymentVersion, entry.resourceType, entry.resourceName);
-    if (entry.directory) {
-      // ZIP up all directories, possibly with additional file prefixes
-      ziputils.zipDirectory(entry.fileName, entry.zipEntryName, function(err, zipBuf) {
-        if (err) {
-          entryDone(err);
-        } else {
-          if (opts.verbose) {
-            console.log('Uploading %s resource %s', entry.resourceType, entry.resourceName);
-          }
-          request({
-            uri: uri,
-            method: 'POST',
-            json: false,
-            headers: { 'Content-Type': 'application/octet-stream' },
-            body: zipBuf
-          }, function(err, req, body) {
-            handleUploadResult(err, req, entryDone);
-          });
-        }
-      });
+// function handleUploadResult(err, req, itemDone) {
+//   if (err) {
+//     itemDone(err);
+//   } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
+//     itemDone();
+//   } else {
+//     itemDone(new Error(util.format('Error uploading resource: %d',
+//       req.statusCode)));
+//   }
+// }
+//
+// function uploadPolicies(opts, request, done) {
+//   var baseDir = path.join(opts.directory, ProxyBase, 'policies');
+//   var fileNames;
+//   try {
+//     fileNames = fs.readdirSync(baseDir);
+//   } catch (e) {
+//     if (e.code === 'ENOENT') {
+//       if (opts.verbose) {
+//         console.log('No policies found');
+//       }
+//       done();
+//     } else {
+//       done(e);
+//     }
+//     return;
+//   }
+//
+//   async.eachLimit(fileNames, opts.asyncLimit, function(fileName, itemDone) {
+//     var rp = path.join(baseDir, fileName);
+//     var stat = fs.statSync(rp);
+//     if (!XmlExp.test(fileName)) {
+//       if (opts.verbose) {
+//         console.log('Skipping file %s which is not an XML file', rp);
+//       }
+//       return itemDone();
+//     }
+//     if (!stat.isFile()) {
+//       if (opts.verbose) {
+//         console.log('Skipping file %s which is not a regular file', rp);
+//       }
+//       return itemDone();
+//     }
+//
+//     if (opts.verbose) {
+//       console.log('Uploading policy %s', fileName);
+//     }
+//     var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/policies',
+//                 opts.baseuri, opts.organization, opts.api,
+//                 opts.deploymentVersion);
+//     var postReq = request({
+//       uri: uri,
+//       headers: { 'Content-Type': 'application/xml' },
+//       json: false,
+//       method: 'POST'
+//     }, function(err, req, body) {
+//       if (err) {
+//         itemDone(err);
+//       } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
+//         itemDone();
+//       } else {
+//         itemDone(new Error(util.format('Error uploading policy: %s',
+//           req.statusCode)));
+//       }
+//     });
+//
+//     var rf = fs.createReadStream(rp);
+//     rf.pipe(postReq);
+//
+//   }, function(err) {
+//     done(err);
+//   });
+// }
+//
+// function uploadTargets(opts, request, done) {
+//   var baseDir = path.join(opts.directory, ProxyBase, 'targets');
+//   var fileNames;
+//   try {
+//     fileNames = fs.readdirSync(baseDir);
+//   } catch (e) {
+//     if (e.code === 'ENOENT') {
+//       if (opts.verbose) {
+//         console.log('No targets found');
+//       }
+//       done();
+//     } else {
+//       done(e);
+//     }
+//     return;
+//   }
+//
+//   async.eachLimit(fileNames, opts.asyncLimit, function(fileName, itemDone) {
+//     var rp = path.join(baseDir, fileName);
+//     var stat = fs.statSync(rp);
+//     var isXml = XmlExp.exec(fileName);
+//     if (!isXml) {
+//       if (opts.verbose) {
+//         console.log('Skipping file %s which is not an XML file', rp);
+//       }
+//       return itemDone();
+//     }
+//     if (!stat.isFile()) {
+//       if (opts.verbose) {
+//         console.log('Skipping file %s which is not a regular file', rp);
+//       }
+//       return itemDone();
+//     }
+//
+//     if (opts.verbose) {
+//       console.log('Uploading target %s', isXml[1]);
+//     }
+//     var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/targets?name=%s',
+//                 opts.baseuri, opts.organization, opts.api,
+//                 opts.deploymentVersion, isXml[1]);
+//     var postReq = request({
+//       uri: uri,
+//       headers: { 'Content-Type': 'application/xml' },
+//       json: false,
+//       method: 'POST'
+//     }, function(err, req, body) {
+//       if (err) {
+//         itemDone(err);
+//       } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
+//         itemDone();
+//       } else {
+//         itemDone(new Error(util.format('Error uploading target: %s',
+//           req.statusCode)));
+//       }
+//     });
+//
+//     var rf = fs.createReadStream(rp);
+//     rf.pipe(postReq);
+//
+//   }, function(err) {
+//     done(err);
+//   });
+// }
+//
+//
+// function findProxies(opts, cb) {
+//   var baseDir = path.join(opts.directory, ProxyBase, 'proxies');
+//   var fileNames;
+//   try {
+//     fileNames = fs.readdirSync(baseDir);
+//   } catch (e) {
+//     if (e.code === 'ENOENT') {
+//       if (opts.verbose) { console.log('No proxies found'); }
+//       cb();
+//     } else {
+//       cb(e);
+//     }
+//     return;
+//   }
+//
+//   var files = _.map(fileNames,
+//     function(fileName) {
+//       var rp = path.join(baseDir, fileName);
+//       var isXml = XmlExp.exec(fileName);
+//       if (!isXml) {
+//         if (opts.verbose) { console.log('Skipping file %s which is not an XML file', rp); }
+//         return false;
+//       }
+//       var stat = fs.statSync(rp);
+//       if (!stat.isFile()) {
+//         if (opts.verbose) { console.log('Skipping file %s which is not a regular file', rp); }
+//         return false;
+//       }
+//       return rp;
+//     });
+//   cb(null, _.compact(files));
+// }
 
-    } else {
-      if (opts.verbose) {
-        console.log('Uploading %s resource %s', entry.resourceType, entry.resourceName);
-      }
-      var httpReq = request({
-        uri: uri,
-        method: 'POST',
-        json: false,
-        headers: { 'Content-Type': 'application/octet-stream' }
-      }, function(err, req, body) {
-        handleUploadResult(err, req, entryDone);
-      });
-
-      var fileStream = fs.createReadStream(entry.fileName);
-      fileStream.pipe(httpReq);
-    }
-  }, function(err) {
-    done(err);
-  });
-}
-
-function handleUploadResult(err, req, itemDone) {
-  if (err) {
-    itemDone(err);
-  } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
-    itemDone();
-  } else {
-    itemDone(new Error(util.format('Error uploading resource: %d',
-      req.statusCode)));
-  }
-}
-
-function uploadPolicies(opts, request, done) {
-  var baseDir = path.join(opts.directory, ProxyBase, 'policies');
-  var fileNames;
-  try {
-    fileNames = fs.readdirSync(baseDir);
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      if (opts.verbose) {
-        console.log('No policies found');
-      }
-      done();
-    } else {
-      done(e);
-    }
-    return;
-  }
-
-  async.eachLimit(fileNames, opts.asyncLimit, function(fileName, itemDone) {
-    var rp = path.join(baseDir, fileName);
-    var stat = fs.statSync(rp);
-    if (!XmlExp.test(fileName)) {
-      if (opts.verbose) {
-        console.log('Skipping file %s which is not an XML file', rp);
-      }
-      return itemDone();
-    }
-    if (!stat.isFile()) {
-      if (opts.verbose) {
-        console.log('Skipping file %s which is not a regular file', rp);
-      }
-      return itemDone();
-    }
-
-    if (opts.verbose) {
-      console.log('Uploading policy %s', fileName);
-    }
-    var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/policies',
-                opts.baseuri, opts.organization, opts.api,
-                opts.deploymentVersion);
-    var postReq = request({
-      uri: uri,
-      headers: { 'Content-Type': 'application/xml' },
-      json: false,
-      method: 'POST'
-    }, function(err, req, body) {
-      if (err) {
-        itemDone(err);
-      } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
-        itemDone();
-      } else {
-        itemDone(new Error(util.format('Error uploading policy: %s',
-          req.statusCode)));
-      }
-    });
-
-    var rf = fs.createReadStream(rp);
-    rf.pipe(postReq);
-
-  }, function(err) {
-    done(err);
-  });
-}
-
-function uploadTargets(opts, request, done) {
-  var baseDir = path.join(opts.directory, ProxyBase, 'targets');
-  var fileNames;
-  try {
-    fileNames = fs.readdirSync(baseDir);
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      if (opts.verbose) {
-        console.log('No targets found');
-      }
-      done();
-    } else {
-      done(e);
-    }
-    return;
-  }
-
-  async.eachLimit(fileNames, opts.asyncLimit, function(fileName, itemDone) {
-    var rp = path.join(baseDir, fileName);
-    var stat = fs.statSync(rp);
-    var isXml = XmlExp.exec(fileName);
-    if (!isXml) {
-      if (opts.verbose) {
-        console.log('Skipping file %s which is not an XML file', rp);
-      }
-      return itemDone();
-    }
-    if (!stat.isFile()) {
-      if (opts.verbose) {
-        console.log('Skipping file %s which is not a regular file', rp);
-      }
-      return itemDone();
-    }
-
-    if (opts.verbose) {
-      console.log('Uploading target %s', isXml[1]);
-    }
-    var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/targets?name=%s',
-                opts.baseuri, opts.organization, opts.api,
-                opts.deploymentVersion, isXml[1]);
-    var postReq = request({
-      uri: uri,
-      headers: { 'Content-Type': 'application/xml' },
-      json: false,
-      method: 'POST'
-    }, function(err, req, body) {
-      if (err) {
-        itemDone(err);
-      } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
-        itemDone();
-      } else {
-        itemDone(new Error(util.format('Error uploading target: %s',
-          req.statusCode)));
-      }
-    });
-
-    var rf = fs.createReadStream(rp);
-    rf.pipe(postReq);
-
-  }, function(err) {
-    done(err);
-  });
-}
-
-function findProxies(opts, cb) {
-  var baseDir = path.join(opts.directory, ProxyBase, 'proxies');
-  var fileNames;
-  try {
-    fileNames = fs.readdirSync(baseDir);
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      if (opts.verbose) { console.log('No proxies found'); }
-      cb();
-    } else {
-      cb(e);
-    }
-    return;
-  }
-
-  var files = _.map(fileNames,
-    function(fileName) {
-      var rp = path.join(baseDir, fileName);
-      var isXml = XmlExp.exec(fileName);
-      if (!isXml) {
-        if (opts.verbose) { console.log('Skipping file %s which is not an XML file', rp); }
-        return false;
-      }
-      var stat = fs.statSync(rp);
-      if (!stat.isFile()) {
-        if (opts.verbose) { console.log('Skipping file %s which is not a regular file', rp); }
-        return false;
-      }
-      return rp;
-    });
-  cb(null, _.compact(files));
-}
-
-function uploadProxies(opts, request, done) {
-
-  findProxies(opts, function(err, filePaths) {
-    if (err) { return cb(err); }
-
-    async.eachLimit(filePaths, opts.asyncLimit, function(filePath, itemDone) {
-
-      var proxyName = filePath.split(path.sep).pop().split('.')[0];
-      if (opts.verbose) {
-        console.log('Uploading proxy %s', proxyName);
-      }
-      var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/proxies?name=%s',
-        opts.baseuri, opts.organization, opts.api,
-        opts.deploymentVersion, proxyName);
-      var postReq = request({
-        uri: uri,
-        headers: { 'Content-Type': 'application/xml' },
-        json: false,
-        method: 'POST'
-      }, function(err, req, body) {
-        if (err) {
-          itemDone(err);
-        } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
-          itemDone();
-        } else {
-          if (opts.verbose) {
-            console.error('Deployment result: %j', body);
-          }
-          var jsonBody = JSON.parse(body);
-          var errMsg;
-          if (jsonBody && (jsonBody.message)) {
-            errMsg = jsonBody.message;
-          } else {
-            errMsg = util.format('Error uploading proxy: %d',
-              req.statusCode);
-          }
-          itemDone(new Error(errMsg));
-        }
-      });
-
-      var rf = fs.createReadStream(filePath);
-      rf.pipe(postReq);
-
-    }, function(err) {
-      done(err);
-    });
-  });
-}
+// function uploadProxies(opts, request, done) {
+//
+//   findProxies(opts, function(err, filePaths) {
+//     if (err) { return done(err); }
+//
+//     async.eachLimit(filePaths, opts.asyncLimit, function(filePath, itemDone) {
+//
+//       var proxyName = filePath.split(path.sep).pop().split('.')[0];
+//       if (opts.verbose) {
+//         console.log('Uploading proxy %s', proxyName);
+//       }
+//       var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/proxies?name=%s',
+//         opts.baseuri, opts.organization, opts.api,
+//         opts.deploymentVersion, proxyName);
+//       var postReq = request({
+//         uri: uri,
+//         headers: { 'Content-Type': 'application/xml' },
+//         json: false,
+//         method: 'POST'
+//       }, function(err, req, body) {
+//         if (err) {
+//           itemDone(err);
+//         } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
+//           itemDone();
+//         } else {
+//           if (opts.verbose) {
+//             console.error('Deployment result: %j', body);
+//           }
+//           var jsonBody = JSON.parse(body);
+//           var errMsg;
+//           if (jsonBody && (jsonBody.message)) {
+//             errMsg = jsonBody.message;
+//           } else {
+//             errMsg = util.format('Error uploading proxy: %d',
+//               req.statusCode);
+//           }
+//           itemDone(new Error(errMsg));
+//         }
+//       });
+//
+//       var rf = fs.createReadStream(filePath);
+//       rf.pipe(postReq);
+//
+//     }, function(err) {
+//       done(err);
+//     });
+//   });
+// }
 
 function runNpm(opts, request, done) {
   if (!opts.remoteNpm) {

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -18,7 +18,6 @@ var parseDeployments = require('./parsedeployments');
 var ProxyBase = 'apiproxy';
 var XmlExp = /(.+)\.xml$/i;
 var DeploymentDelay = 60;
-var BASE_PATH_REGEXP = /<BasePath[^>]*>(.*?)<\/BasePath>/;
 
 // By default, do not run NPM remotely
 var DefaultResolveModules = false;
@@ -38,10 +37,6 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Directory',
     shortOption: 'd',
     required: false
-  },
-  'base-path': {
-    name: 'Base Path',
-    shortOption: 'b'
   },
   'import-only': {
     name: 'Import Only',
@@ -82,9 +77,6 @@ module.exports.run = function(opts, cb) {
 
   // Run each function in series, and collect an array of results.
   async.series([
-    function(done) {
-      checkBasePath(opts, done);
-    },
     function(done) {
       getDeploymentInfo(opts, request, done);
     },
@@ -135,23 +127,6 @@ module.exports.run = function(opts, cb) {
         cb);
     });
 };
-
-function checkBasePath(opts, cb) {
-  if (!opts['base-path']) { return cb(); }
-  findProxies(opts, function(err, files) {
-    if (files.length !== 1) {
-      return cb(new Error('Cannot specify base-path option when more than one ProxyEndpoint'));
-    }
-    fs.readFile(files[0], 'utf8', function(err, data) {
-      if (err) { return cb(err); }
-      var match = data.match(BASE_PATH_REGEXP);
-      if (match && match[1] !== opts['base-path']) {
-        return cb(new Error(util.format('Cannot override ProxyEndpoint BasePath: %s', match[1])));
-      }
-      cb();
-    });
-  });
-}
 
 function getDeploymentInfo(opts, request, done) {
   // Find out if the root directory is a directory
@@ -616,13 +591,9 @@ function deployProxy(opts, request, done) {
 
     var uri = util.format('%s/v1/o/%s/e/%s/apis/%s/revisions/%d/deployments',
       opts.baseuri, opts.organization, environment, opts.api, opts.deploymentVersion);
-    if (opts.debug) { console.log('Going to POST to %s', uri); }
-
     var deployCmd = util.format('action=deploy&override=true&delay=%d', DeploymentDelay);
-    if (opts['base-path']) {
-      deployCmd = util.format('%s&basepath=%s', deployCmd, opts['base-path']);
-    }
-    if (opts.debug) { console.log('Going go send command %s', deployCmd); }
+
+    if (opts.debug) { console.log('Going to POST to %s\n              %s', uri, deployCmd); }
 
     request({
       uri: uri,

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -29,7 +29,7 @@ var DefaultDescriptor = {
   },
   netrc: {
     name: 'netrc',
-    shortOption: 'n',
+    shortOption: 'N',
     required: false,
     toggle: true
   },

--- a/lib/options.js
+++ b/lib/options.js
@@ -45,7 +45,7 @@ module.exports.TableFormat = TableFormat;
        }
 
      } else {
-       var shortArg = /^-([A-Za-z])/.exec(argv[i]);
+       var shortArg = /^-([A-Za-z0-9])/.exec(argv[i]);
        if (shortArg) {
          var shortArgName = shortArg[1];
          var longName;

--- a/lib/ziputils.js
+++ b/lib/ziputils.js
@@ -33,10 +33,19 @@ module.exports.zipDirectory = function(dirName, prefix, cb) {
     cb = prefix;
     prefix = undefined;
   }
+  return zipDirectoryFiltered(dirName, prefix, undefined, cb);
+};
+module.exports.zipDirectoryFiltered = zipDirectoryFiltered;
 
+function zipDirectoryFiltered(dirName, prefix, filter, cb) {
+  if (typeof prefix === 'function') {
+    cb = filter;
+    filter = prefix;
+    prefix = undefined;
+  }
   var pf = (prefix ? prefix : '.');
   var arch = new zip();
-  zipDirectory(arch, dirName, pf, function(err) {
+  zipDirectory(arch, dirName, pf, filter, function(err) {
     if (err) {
       cb(err);
     } else {
@@ -45,9 +54,9 @@ module.exports.zipDirectory = function(dirName, prefix, cb) {
       cb(undefined, contents);
     }
   });
-};
+}
 
-function zipDirectory(baseArch, baseName, entryName, done) {
+function zipDirectory(baseArch, baseName, entryName, filterFn, done) {
   // Create an object that is now relative to the last ZIP entry name
   var arch = baseArch.folder(entryName);
 
@@ -60,25 +69,30 @@ function zipDirectory(baseArch, baseName, entryName, done) {
     // Iterate over each file in the directory
     async.eachSeries(files, function(fileName, itemDone) {
       var fn = path.join(baseName, fileName);
-      fs.stat(fn, function(err, stat) {
-        if (err) {
-          itemDone(err);
-        } else if (stat.isDirectory()) {
-          // Recursively ZIP additional directories
-          zipDirectory(arch, fn, fileName, itemDone);
+      if ((typeof filterFn !== 'function') || filterFn(fn)) {
+        fs.stat(fn, function(err, stat) {
+          if (err) {
+            itemDone(err);
+          } else if (stat.isDirectory()) {
+            // Recursively ZIP additional directories
+            zipDirectory(arch, fn, fileName, filterFn, itemDone);
 
-        } else if (stat.isFile()) {
-          // Aysynchronously read the file and store it in the ZIP.
-          fs.readFile(fn, function(err, contents) {
-            if (err) {
-              itemDone(err);
-            } else {
-              arch.file(fileName, contents);
-              itemDone();
-            }
-          });
-        }
-      });
+          } else if (stat.isFile()) {
+            // Aysynchronously read the file and store it in the ZIP.
+            fs.readFile(fn, function(err, contents) {
+              if (err) {
+                itemDone(err);
+              } else {
+                arch.file(fileName, contents);
+                itemDone();
+              }
+            });
+          }
+        });
+      }
+      else {
+         itemDone();
+      }
     }, function(err) {
       done(err);
     });


### PR DESCRIPTION
Sorry, these are unrelated changes, all collapsed into a single PR.

Four changes: 
1. the retrieve creds from netrc was not working with the short-option,  because it was configured to use  -n , which was already in use for the api name.  The short option is now -N .
2.  the deployproxy command now has a new talent.  Using the -1 or --one-zip option, it will import in one big happy zip.  This may or may not be valuable. The existing behavior remains unchanged.
3. the --base-path option on deployproxy is now implemented and documented correctly. Basically it prepends an additional path to the basepath in any proxyendpoint in the bundle. The prepended path need not be the same as the path in the bundle, of course.  Previously it insisted on matching the path in the proxyendpoint, and for that reason it wouldn't work if there was more than one proxyendpoint.  Also it wasn't documented clearly. This is now fixed.
4. Readme updates for the above as well as unrelated typo fixes. 

Let me know if this combined PR doesn't work. In that case, I can separate them and file individual PRs.
