### PR TITLE
create and delete cache resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,4 +399,4 @@ https://github.com/apigee/api-platform-tools
 
 # <a name="contrib"></a>Contribution
 
-To run remotetests, provide your edge creds, org, env details in `remotetest/testconfig-sample.js`
+To run remotetests, provide your edge creds, org, env details in `remotetest/testconfig.js` similar to 'remotetest/testconfig-sample.js'

--- a/README.md
+++ b/README.md
@@ -399,4 +399,4 @@ https://github.com/apigee/api-platform-tools
 
 # <a name="contrib"></a>Contribution
 
-To run remotetests, provide your edge creds, org, env details in `testconfig-sample.js`
+To run remotetests, provide your edge creds, org, env details in `remotetest/testconfig-sample.js`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a tool for deploying API proxies and Node.js applications to the Apigee 
 * [What you need to know about apigeetool](#whatyouneed)
 * [Command reference and examples](#reference)
 * [Original tool](#original)
+* [Contribution](#contrib)
 
 # <a name="installation"></a>Installation
 
@@ -395,3 +396,7 @@ This module replaces the original "apigeetool," which was written in Python.
 It is also called "apigeetool" and resides here:
 
 https://github.com/apigee/api-platform-tools
+
+# <a name="contrib"></a>Contribution
+
+To run remotetests, provide your edge creds, org, env details in `testconfig-sample.js`

--- a/lib/commands/commands.js
+++ b/lib/commands/commands.js
@@ -48,6 +48,18 @@ var Commands = {
     load: function() {
       return require('./delete');
     }
+  },
+  createcache: {
+    description: 'Create a new Cache Resource in the environment',
+    load: function(){
+      return require('./createcache')
+    }
+  },
+  deletecache: {
+    description: 'Deletes a Cache Resource in the environment',
+    load: function(){
+      return require('./deletecache')
+    }
   }
 };
 

--- a/lib/commands/createcache.js
+++ b/lib/commands/createcache.js
@@ -63,7 +63,7 @@ function createCache(opts, request, done){
 		  "inMemorySizeInKB" : 1024,
 		  "maxElementsInMemory" : 100,
 		  "maxElementsOnDisk" : 100,
-		  "name" : "cache1",
+		  "name" : opts.cache,
 		  "overflowToDisk" : true,
 		  "persistent" : true,
 		  "skipCacheIfElementSizeInKBExceeds" : 512

--- a/lib/commands/createcache.js
+++ b/lib/commands/createcache.js
@@ -22,31 +22,25 @@ var descriptor = defaults.defaultDescriptor({
 
 module.exports.descriptor = descriptor;
 
-
 module.exports.run = function(opts, cb) {
   options.validateSync(opts, descriptor);
   if (opts.debug) {
     console.log('createcache: %j', opts);
   }
-
   var request = defaults.defaultRequest(opts);
-
-    createCache(opts, request, function(err, results) {
+  createCache(opts, request, function(err, results) {
       if (err) {
         cb(err);
       } else {
         if (opts.debug) {
           console.log('results: %j', results);
         }
-
         cb(undefined, {});
       }
     });
 };
 
-
 function createCache(opts, request, done){
-
 	var createCachePayload  = {
 		  "compression" : {
 		    "minimumSizeInKB" : 512
@@ -70,7 +64,6 @@ function createCache(opts, request, done){
 	}
 
 	var uri = util.format('%s/v1/o/%s/e/%s/caches', opts.baseuri, opts.organization, opts.environment);
-	
 	request({
 		uri: uri,
 		method:'POST',
@@ -79,7 +72,7 @@ function createCache(opts, request, done){
 	},function(err,res,body){
 		var jsonBody = body
 		if(err){
-
+			done(err)
 		}else if (res.statusCode === 201) {
 			if (opts.verbose) {
        		 console.log('Delete successful');
@@ -92,7 +85,6 @@ function createCache(opts, request, done){
 	      if (opts.verbose) {
 	        console.error('Create Cache result: %j', body);
 	      }
-
 	      var errMsg;
 	      if (jsonBody && (jsonBody.message)) {
 	        errMsg = jsonBody.message;

--- a/lib/commands/createcache.js
+++ b/lib/commands/createcache.js
@@ -1,0 +1,105 @@
+/* jshint node: true  */
+'use strict';
+
+var util = require('util');
+var _ = require('underscore');
+
+var defaults = require('../defaults');
+var options = require('../options');
+
+var descriptor = defaults.defaultDescriptor({
+  environment: {
+    name: 'Environment',
+    shortOption: 'e',
+    required: true
+  },
+  cache: {
+    name: 'Cache Resource',
+    shortOption: 'r',
+    required: true
+  }
+});
+
+module.exports.descriptor = descriptor;
+
+
+module.exports.run = function(opts, cb) {
+  options.validateSync(opts, descriptor);
+  if (opts.debug) {
+    console.log('createcache: %j', opts);
+  }
+
+  var request = defaults.defaultRequest(opts);
+
+    createCache(opts, request, function(err, results) {
+      if (err) {
+        cb(err);
+      } else {
+        if (opts.debug) {
+          console.log('results: %j', results);
+        }
+
+        cb(undefined, {});
+      }
+    });
+};
+
+
+function createCache(opts, request, done){
+
+	var createCachePayload  = {
+		  "compression" : {
+		    "minimumSizeInKB" : 512
+		  },
+		  "description" : "Store Response",
+		  "diskSizeInMB" : 1024,
+		  "distributed" : true,
+		  "expirySettings" : {
+		    "expiryDate" : {
+		      "value" : "12-31-9999"
+		    },
+		    "valuesNull" : false
+		  },
+		  "inMemorySizeInKB" : 1024,
+		  "maxElementsInMemory" : 100,
+		  "maxElementsOnDisk" : 100,
+		  "name" : "cache1",
+		  "overflowToDisk" : true,
+		  "persistent" : true,
+		  "skipCacheIfElementSizeInKBExceeds" : 512
+	}
+
+	var uri = util.format('%s/v1/o/%s/e/%s/caches', opts.baseuri, opts.organization, opts.environment);
+	
+	request({
+		uri: uri,
+		method:'POST',
+		body: createCachePayload,
+		json:true
+	},function(err,res,body){
+		var jsonBody = body
+		if(err){
+
+		}else if (res.statusCode === 201) {
+			if (opts.verbose) {
+       		 console.log('Delete successful');
+      		}
+		    if (opts.debug) {
+		       console.log('%s', body);
+		    }
+      		done(undefined, jsonBody);
+		}else {
+	      if (opts.verbose) {
+	        console.error('Create Cache result: %j', body);
+	      }
+
+	      var errMsg;
+	      if (jsonBody && (jsonBody.message)) {
+	        errMsg = jsonBody.message;
+	      } else {
+	        errMsg = util.format('Create Cache failed with status code %d', res.statusCode);
+	      }
+	      done(new Error(errMsg));
+    	}
+	})
+}

--- a/lib/commands/createcache.js
+++ b/lib/commands/createcache.js
@@ -15,7 +15,7 @@ var descriptor = defaults.defaultDescriptor({
   },
   cache: {
     name: 'Cache Resource',
-    shortOption: 'r',
+    shortOption: 'z',
     required: true
   }
 });

--- a/lib/commands/deletecache.js
+++ b/lib/commands/deletecache.js
@@ -1,0 +1,84 @@
+/* jshint node: true  */
+'use strict';
+
+var util = require('util');
+var _ = require('underscore');
+
+var defaults = require('../defaults');
+var options = require('../options');
+
+var descriptor = defaults.defaultDescriptor({
+  environment: {
+    name: 'Environment',
+    shortOption: 'e',
+    required: true
+  },
+  cache: {
+    name: 'Cache Resource',
+    shortOption: 'r',
+    required: true
+  }
+});
+
+module.exports.descriptor = descriptor;
+
+
+module.exports.run = function(opts, cb) {
+  options.validateSync(opts, descriptor);
+  if (opts.debug) {
+    console.log('deletecache: %j', opts);
+  }
+
+  var request = defaults.defaultRequest(opts);
+
+    deleteCache(opts, request, function(err, results) {
+      if (err) {
+        cb(err);
+      } else {
+        if (opts.debug) {
+          console.log('results: %j', results);
+        }
+
+        cb(undefined, {});
+      }
+    });
+};
+
+
+function deleteCache(opts, request, done){
+
+	
+
+	var uri = util.format('%s/v1/o/%s/e/%s/caches/%s', opts.baseuri, opts.organization, opts.environment,opts.cache);
+	
+	request({
+		uri: uri,
+		method:'DELETE',
+		json:false
+	},function(err,res,body){
+		var jsonBody = body
+		if(err){
+
+		}else if (res.statusCode === 200) {
+			if (opts.verbose) {
+       		 console.log('Delete successful');
+      		}
+		    if (opts.debug) {
+		       console.log('%s', body);
+		    }
+      		done(undefined, jsonBody);
+		}else {
+	      if (opts.verbose) {
+	        console.error('Delete Cache result: %j', body);
+	      }
+
+	      var errMsg;
+	      if (jsonBody && (jsonBody.message)) {
+	        errMsg = jsonBody.message;
+	      } else {
+	        errMsg = util.format('Delete Cache failed with status code %d', res.statusCode);
+	      }
+	      done(new Error(errMsg));
+    	}
+	})
+}

--- a/lib/commands/deletecache.js
+++ b/lib/commands/deletecache.js
@@ -22,35 +22,26 @@ var descriptor = defaults.defaultDescriptor({
 
 module.exports.descriptor = descriptor;
 
-
 module.exports.run = function(opts, cb) {
   options.validateSync(opts, descriptor);
   if (opts.debug) {
     console.log('deletecache: %j', opts);
   }
-
   var request = defaults.defaultRequest(opts);
-
-    deleteCache(opts, request, function(err, results) {
+  deleteCache(opts, request, function(err, results) {
       if (err) {
         cb(err);
       } else {
         if (opts.debug) {
           console.log('results: %j', results);
         }
-
         cb(undefined, {});
       }
     });
 };
 
-
 function deleteCache(opts, request, done){
-
-	
-
-	var uri = util.format('%s/v1/o/%s/e/%s/caches/%s', opts.baseuri, opts.organization, opts.environment,opts.cache);
-	
+	var uri = util.format('%s/v1/o/%s/e/%s/caches/%s', opts.baseuri, opts.organization, opts.environment,opts.cache);	
 	request({
 		uri: uri,
 		method:'DELETE',
@@ -58,7 +49,7 @@ function deleteCache(opts, request, done){
 	},function(err,res,body){
 		var jsonBody = body
 		if(err){
-
+			done(err)
 		}else if (res.statusCode === 200) {
 			if (opts.verbose) {
        		 console.log('Delete successful');
@@ -71,7 +62,6 @@ function deleteCache(opts, request, done){
 	      if (opts.verbose) {
 	        console.error('Delete Cache result: %j', body);
 	      }
-
 	      var errMsg;
 	      if (jsonBody && (jsonBody.message)) {
 	        errMsg = jsonBody.message;

--- a/lib/commands/deletecache.js
+++ b/lib/commands/deletecache.js
@@ -15,7 +15,7 @@ var descriptor = defaults.defaultDescriptor({
   },
   cache: {
     name: 'Cache Resource',
-    shortOption: 'r',
+    shortOption: 'z',
     required: true
   }
 });

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -284,8 +284,9 @@ function uploadResources(opts, request, done) {
     }
     return;
   }
-
-  async.eachLimit(entries, opts.asyncLimit, function(entry, entryDone) {
+  
+  async.eachLimit(entries, opts.asynclimit, function(entry, entryDone) {
+    console.log(entry)
     var uri =
       util.format('%s/v1/o/%s/apis/%s/revisions/%d/resources?type=%s&name=%s',
                   opts.baseuri, opts.organization, opts.api,
@@ -294,6 +295,7 @@ function uploadResources(opts, request, done) {
       // ZIP up all directories, possibly with additional file prefixes
       ziputils.zipDirectory(entry.fileName, entry.zipEntryName, function(err, zipBuf) {
         if (err) {
+          console.log(err)
           entryDone(err);
         } else {
           if (opts.verbose) {
@@ -360,7 +362,7 @@ function uploadPolicies(opts, request, done) {
     return;
   }
 
-  async.eachLimit(fileNames, opts.asyncLimit, function(fileName, itemDone) {
+  async.eachLimit(fileNames, opts.asynclimit, function(fileName, itemDone) {
     var rp = path.join(baseDir, fileName);
     var stat = fs.statSync(rp);
     if (!XmlExp.test(fileName)) {
@@ -423,7 +425,7 @@ function uploadTargets(opts, request, done) {
     return;
   }
 
-  async.eachLimit(fileNames, opts.asyncLimit, function(fileName, itemDone) {
+  async.eachLimit(fileNames, opts.asynclimit, function(fileName, itemDone) {
     var rp = path.join(baseDir, fileName);
     var stat = fs.statSync(rp);
     var isXml = XmlExp.exec(fileName);
@@ -508,7 +510,7 @@ function uploadProxies(opts, request, done) {
   findProxies(opts, function(err, filePaths) {
     if (err) { return cb(err); }
 
-    async.eachLimit(filePaths, opts.asyncLimit, function(filePath, itemDone) {
+    async.eachLimit(filePaths, opts.asynclimit, function(filePath, itemDone) {
 
       var proxyName = filePath.split(path.sep).pop().split('.')[0];
       if (opts.verbose) {

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -76,8 +76,7 @@ module.exports.run = function(opts, cb) {
   options.validateSync(opts, descriptor);
   if (opts.debug) {
     console.log('deployproxy: %j', opts);
-  }
-
+  }  
   var request = defaults.defaultRequest(opts);
 
   // Run each function in series, and collect an array of results.
@@ -107,10 +106,10 @@ module.exports.run = function(opts, cb) {
       runNpm(opts, request, done);
     },
     function(done) {
-      deployProxy(opts, request, done);
+      deployProxy(opts, request, done);      
     }
     ],
-    function(err, results) {
+    function(err, results) {      
       if (err) { return cb(err); }
       if (opts.debug) { console.log('results: %j', results); }
 
@@ -126,9 +125,10 @@ module.exports.run = function(opts, cb) {
               // Ignore this error because deployment worked
               if (err && opts.verbose) { console.log('Error looking up deployed path: %s', err); }
               cb(undefined, deployment);
+              
             });
           } else {
-            // Probably import-only -- do nothing
+            // Probably import-only -- do nothing          
             cb(undefined, {});
           }
         },

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -286,7 +286,6 @@ function uploadResources(opts, request, done) {
   }
   
   async.eachLimit(entries, opts.asynclimit, function(entry, entryDone) {
-    console.log(entry)
     var uri =
       util.format('%s/v1/o/%s/apis/%s/revisions/%d/resources?type=%s&name=%s',
                   opts.baseuri, opts.organization, opts.api,

--- a/lib/commands/parsedeployments.js
+++ b/lib/commands/parsedeployments.js
@@ -103,7 +103,7 @@ module.exports.getPathInfo = function(deployments, opts, cb) {
   /*deployments = deployments.filter(function( d){
        return d.state === 'deployed'
    })*/
-  async.eachLimit(deployments, opts.asyncLimit, function(item, done) {
+  async.eachLimit(deployments, opts.asynclimit, function(item, done) {
     fillInProxies(item, opts, request, done);
   }, function(err) {
     if (opts.debug) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,6 +49,16 @@ ApigeeTool.delete = function(opts, cb) {
   runCommand(cmd, opts, cb);
 };
 
+ApigeeTool.createcache = function(opts, cb) {
+  var cmd = require('./commands/createcache');
+  runCommand(cmd, opts, cb);
+};
+
+ApigeeTool.deletecache = function(opts, cb) {
+  var cmd = require('./commands/deletecache');
+  runCommand(cmd, opts, cb);
+};
+
 function runCommand(cmd, opts, cb) {
   options.validate(opts, cmd.descriptor, function(err) {
     if (err) {

--- a/remotetests/remotetest.js
+++ b/remotetests/remotetest.js
@@ -8,7 +8,7 @@ var util = require('util');
 var stream = require('stream');
 var _ = require('underscore');
 
-var config = require('./testconfig-sample');
+var config = require('./testconfig');
 
 var REASONABLE_TIMEOUT = 120000;
 var APIGEE_PROXY_NAME = 'apigee-cli-apigee-test';


### PR DESCRIPTION
added support for create and delete cache resources, plus fixed the existing remote tests,

To run remote tests, create a `remotetests/testconfig.js`, provide your edge credentials like the `remotetests/testconfig-sample.js`, then run remote tests using `mocha -R spec remotetests`

few existing remote tests were failing - i guess, because the deployment API might have changed - it returns an array now instead of object
