### PR TITLE
Added support for supplying target endpoint XML to deploynodeapp.

### DIFF
--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -72,6 +72,11 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Preserve policies from previous revision',
     shortOption: 'P',
     toggle: true
+  },
+  'target-endpoint': {
+    name: 'Target Endpoint',
+    shortOption: 't',
+    required: false
   }
 });
 module.exports.descriptor = descriptor;
@@ -503,6 +508,10 @@ function createTarget(opts, request, done) {
     '<ResourceURL>node://{{main}}</ResourceURL>' +
     '</ScriptTarget>' +
     '</TargetEndpoint>', opts);
+
+  if (opts['target-endpoint']) {
+    targetDoc = fs.readFileSync(opts['target-endpoint']);
+  }
 
   var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/targets?name=default',
               opts.baseuri, opts.organization, opts.api,


### PR DESCRIPTION
Allows you to supply a path for a target endpoint config file with `-t`.
