### PR TITLE
Basepath fix - eliminate check on basepath in deployproxy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Currently this only affects file uploads in the `deploynodeapp` command. Default
 (required) Your Apigee account username. May be set as an environment variable APIGEE_USERNAME.
 
 `--token -t`
-(optional) Your Apigee access token. Use this in lieu of -u / -p
+(optional) Your Apigee access token. Use this in lieu of -u / -p/
 
-`--netrc  -N`  
+`--netrc  -n`  
 (optional) Use this in lieu of -u / -p, to tell apigeetool to retrieve credentials from your .netrc file.
 
 `--verbose   -V`  
@@ -412,24 +412,24 @@ should be a name such as "PST."
 You could use apigeetool as an SDK to orchestrate tasks that you want to perform with Edge, for eg, deploying an api proxy or running tests etc.
 
 #### Usage Example
-        
-        var apigeetool = require('apigeetool')
-        var sdk = apigeetool.getPromiseSDK()
-        var opts = {
-            organization: 'edge-org',
-            username: 'edge-user',
-            password: 'password',
-            environment: 'environment',  
-        }
-        opts.api = APIGEE_PROXY_NAME;
+	
+	var apigeetool = require('apigeetool')
+	var sdk = apigeetool.getPromiseSDK()
+	var opts = {
+	    organization: 'edge-org',
+	    username: 'edge-user',
+	    password: 'password',
+	    environment: 'environment',	 
+  	}
+	opts.api = APIGEE_PROXY_NAME;
     opts.directory = path.join(__dirname);    
 
-        sdk.deployProxy(opts)
-                .then(function(result){
-                        //deploy success
-                        },function(err){
-                        //deploy failed 
-                })
+	sdk.deployProxy(opts)
+		.then(function(result){
+			//deploy success
+			},function(err){
+			//deploy failed	
+		})
 
 ## <a name="createdeveloper"></a>Create Developer
 
@@ -438,9 +438,9 @@ Creates a new Developer in Edge
 #### Example
 
 Create a developer.
-        
-        //see above for other required options
-        opts.email = DEVELOPER_EMAIL
+	
+	//see above for other required options
+	opts.email = DEVELOPER_EMAIL
     opts.firstName = 'Test'
     opts.lastName = 'Test1'
     opts.userName = 'runningFromTest123'
@@ -459,8 +459,8 @@ Delete a Developer in Edge
 
 #### Example
 
-        //see above for other required options
-        opts.email = DEVELOPER_EMAIL
+	//see above for other required options
+	opts.email = DEVELOPER_EMAIL
 
     sdk.deleteDeveloper(opts)
       .then(function(result){

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -76,14 +76,11 @@ module.exports.run = function(opts, cb) {
   options.validateSync(opts, descriptor);
   if (opts.debug) {
     console.log('deployproxy: %j', opts);
-  }  
+  }
   var request = defaults.defaultRequest(opts);
 
   // Run each function in series, and collect an array of results.
   async.series([
-    function(done) {
-      checkBasePath(opts, done);
-    },
     function(done) {
       getDeploymentInfo(opts, request, done);
     },
@@ -106,10 +103,10 @@ module.exports.run = function(opts, cb) {
       runNpm(opts, request, done);
     },
     function(done) {
-      deployProxy(opts, request, done);      
+      deployProxy(opts, request, done);
     }
     ],
-    function(err, results) {      
+    function(err, results) {
       if (err) { return cb(err); }
       if (opts.debug) { console.log('results: %j', results); }
 
@@ -125,33 +122,16 @@ module.exports.run = function(opts, cb) {
               // Ignore this error because deployment worked
               if (err && opts.verbose) { console.log('Error looking up deployed path: %s', err); }
               cb(undefined, deployment);
-              
+
             });
           } else {
-            // Probably import-only -- do nothing          
+            // Probably import-only -- do nothing
             cb(undefined, {});
           }
         },
         cb);
     });
 };
-
-function checkBasePath(opts, cb) {
-  if (!opts['base-path']) { return cb(); }
-  findProxies(opts, function(err, files) {
-    if (files.length !== 1) {
-      return cb(new Error('Cannot specify base-path option when more than one ProxyEndpoint'));
-    }
-    fs.readFile(files[0], 'utf8', function(err, data) {
-      if (err) { return cb(err); }
-      var match = data.match(BASE_PATH_REGEXP);
-      if (match && match[1] !== opts['base-path']) {
-        return cb(new Error(util.format('Cannot override ProxyEndpoint BasePath: %s', match[1])));
-      }
-      cb();
-    });
-  });
-}
 
 function getDeploymentInfo(opts, request, done) {
   // Find out if the root directory is a directory
@@ -198,7 +178,7 @@ function getDeploymentInfo(opts, request, done) {
       } else if (req.statusCode === 200) {
         opts.deploymentVersion =
           parseInt(_.max(body.revision, function(r) { return parseInt(r); })) + 1;
-        if (opts.verbose) {
+        if (opts.verbose || opts.debug) {
           console.log('Going to create revision %d of API %s',
                       opts.deploymentVersion, opts.api);
         }
@@ -257,6 +237,9 @@ function proxyCreationDone(err, req, body, opts, done) {
   if (err) {
     done(err);
   } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
+    if (opts.verbose) {
+      console.log('Proxy creation done');
+    }
     done();
   } else {
     if (opts.verbose) {
@@ -284,7 +267,7 @@ function uploadResources(opts, request, done) {
     }
     return;
   }
-  
+
   async.eachLimit(entries, opts.asynclimit, function(entry, entryDone) {
     var uri =
       util.format('%s/v1/o/%s/apis/%s/revisions/%d/resources?type=%s&name=%s',
@@ -294,7 +277,7 @@ function uploadResources(opts, request, done) {
       // ZIP up all directories, possibly with additional file prefixes
       ziputils.zipDirectory(entry.fileName, entry.zipEntryName, function(err, zipBuf) {
         if (err) {
-          console.log(err)
+          console.log(err);
           entryDone(err);
         } else {
           if (opts.verbose) {
@@ -617,13 +600,11 @@ function deployProxy(opts, request, done) {
 
     var uri = util.format('%s/v1/o/%s/e/%s/apis/%s/revisions/%d/deployments',
       opts.baseuri, opts.organization, environment, opts.api, opts.deploymentVersion);
-    if (opts.debug) { console.log('Going to POST to %s', uri); }
-
     var deployCmd = util.format('action=deploy&override=true&delay=%d', DeploymentDelay);
     if (opts['base-path']) {
       deployCmd = util.format('%s&basepath=%s', deployCmd, opts['base-path']);
     }
-    if (opts.debug) { console.log('Going go send command %s', deployCmd); }
+    if (opts.debug) { console.log('Going to POST to %s\n        command: %s', uri, deployCmd); }
 
     request({
       uri: uri,

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -37,7 +37,7 @@ var DefaultDescriptor = {
   },
   netrc: {
     name: 'netrc',
-    shortOption: 'N',
+    shortOption: 'n',
     required: false,
     toggle: true
   },


### PR DESCRIPTION
The deployproxy command was implemented under the assumption that the basepath option that is supported in the REST api overrides or replaces the basepath specified in the proxy endpoint configuration. This is not strictly true. In fact the basepath that can be supplied in the API call prepends to the basepath in the API proxy endpoint. Therefore, the checkBasePath() function in the deployproxy command is unnecessary and inappropriate: A. the basepath can be applied when multiple proxies are being deployed, and B. the basepath provided in the command need not match the basepath specified in the apiproxy endpoint. This PR just removes the unnecessary check.
@theganyo 
