### PR TITLE
Disabling strictSSL when -k flag is set

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -174,6 +174,8 @@ module.exports.defaultRequest = function(opts) {
 
   if (opts.insecure) {
     ro.agentOptions.rejectUnauthorized = false;
+    // Skips certificate validation 
+    ro.strictSSL = false;
   }
 
   return request.defaults(ro);


### PR DESCRIPTION
https://github.com/apigee/apigeetool-node/issues/33

I don't seem to be the only one with this problem. Our corporate proxy currently requires the strictSSL option. Setting strictSSL to false would skip checking the SSL certificates.

