### PR TITLE
show which policy failed upload on failure

### DIFF
--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -394,8 +394,8 @@ function uploadPolicies(opts, request, done) {
       } else if ((req.statusCode === 200) || (req.statusCode === 201)) {
         itemDone();
       } else {
-        itemDone(new Error(util.format('Error uploading policy: %s',
-          req.statusCode)));
+        itemDone(new Error(util.format('Error uploading policy: %s. Status code: %s',
+          fileName, req.statusCode)));
       }
     });
 


### PR DESCRIPTION
When an upload of policy fails (eg due to badly written policy) it currently just says failed and a status code. This makes it hard to track where the problem is if you have many policy files. 
This change shows which file caused the problem