### PR TITLE
Changed -r parameter of fetchproxy to be required

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ for organization name, all of which are required.
 (required) The name of the API proxy or app to undeploy.
 
 `--revision  -r`
-(optional) Specifies the revision to retrieve.
+(required) Specifies the revision to retrieve.
 
 #### Optional parameters
 


### PR DESCRIPTION
According to https://github.com/apigee/apigeetool-node/blob/master/lib/commands/fetchproxy.js#L21 -r parameter is required