### PR TITLE
add hosted functions support to getlogs

### DIFF
--- a/lib/commands/getlogs.js
+++ b/lib/commands/getlogs.js
@@ -8,6 +8,9 @@ var defaults = require('../defaults');
 var options = require('../options');
 
 var STREAM_DELAY = 5000;
+var CATEGORY_NODEJS = 'nodejs';
+var CATEGORY_HOSTED_BUILD = 'hostedtarget-build';
+var CATEGORY_HOSTED_RUNTIME = 'hostedtarget-runtime';
 
 var descriptor = defaults.defaultDescriptor({
   api: {
@@ -30,6 +33,16 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Time Zone',
     shortOption: 'z',
     required: false
+  },
+  'hosted-runtime': {
+    name: 'Hosted Functions Runtime Logs',
+    toggle: true,
+    required: false
+  },
+  'hosted-build': {
+    name: 'Hosted Functions Build Logs',
+    toggle: true,
+    required: false
   }
 });
 module.exports.descriptor = descriptor;
@@ -47,6 +60,13 @@ module.exports.run = function(opts, cb) {
 
   var request = defaults.defaultRequest(opts);
 
+  opts['category'] = CATEGORY_NODEJS;
+  if (opts['hosted-build'] !== undefined) {
+    opts['category'] = CATEGORY_HOSTED_BUILD;
+  } else if (opts['hosted-runtime'] !== undefined) {
+    opts['category'] = CATEGORY_HOSTED_RUNTIME;
+  }
+
   var outStream = (opts.stream ? opts.stream : process.stdout);
   if (opts.streaming) {
     makeStreamRequest(request, opts, outStream, cb);
@@ -57,9 +77,9 @@ module.exports.run = function(opts, cb) {
 
 function makeOneRequest(request, opts, outStream, cb) {
   var uri = util.format(
-    '%s/v1/o/%s/e/%s/apis/%s/cachedlogs/categories/nodejs',
+    '%s/v1/o/%s/e/%s/apis/%s/cachedlogs/categories/%s',
     opts.baseuri, opts.organization, opts.environment,
-    opts.api);
+    opts.api, opts.category);
   if (opts.timezone) {
     uri += util.format('?tz=%s', opts.timezone);
   }


### PR DESCRIPTION
Add two flags to toggle the logs category `--hosted-runtime` and `--hosted-build`.