### PR TITLE
disable streaming for hosted logs

### DIFF
--- a/lib/commands/getlogs.js
+++ b/lib/commands/getlogs.js
@@ -67,6 +67,14 @@ module.exports.run = function(opts, cb) {
     opts['category'] = CATEGORY_HOSTED_RUNTIME;
   }
 
+  if (opts['streaming'] && 
+    (opts['category'] === CATEGORY_HOSTED_BUILD ||
+    opts['category'] === CATEGORY_HOSTED_RUNTIME)) {
+    
+      console.log('Log streaming is currently disabled for hosted-build & hosted-runtime logs')
+      opts['streaming'] = false;
+  }
+
   var outStream = (opts.stream ? opts.stream : process.stdout);
   if (opts.streaming) {
     makeStreamRequest(request, opts, outStream, cb);


### PR DESCRIPTION
We are working on more involved Log API changes that will bring support for the `getlogs --streaming` functionality. Until then, we must disable it for `hosted` categories