### PR TITLE
Added `wait-after-import (-W)` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ for organization name, all of which are required.
 `--virtualhosts  -v`  
 (optional) A comma-separated list of virtual hosts that the deployed app will use. The two most common options are `default` and `secure`. The `default` option is always HTTP and `secure` is always HTTPS. By default, `apigeetool deploynodeapp` uses `default,secure`.
 
+`--wait-after-import  -W`  
+(optional) Number of seconds to delay before deploying node.js proxy.
+
 ## <a name="deployproxy"></a>deployproxy
 
 Deploys an API proxy to Apigee Edge. If the proxy is currently deployed, it will be undeployed first, and the newly deployed proxy's revision number is incremented.
@@ -211,6 +214,9 @@ for organization name, all of which are required.
 
 `--upload-modules    -U`  
 (optional) If specified, uploads Node.js modules from your system to Apigee Edge.
+
+`--wait-after-import  -W`  
+(optional) Number of seconds to delay before deploying node.js proxy.
 
 ## <a name="undeploy"></a>undeploy
 

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -72,6 +72,11 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Preserve policies from previous revision',
     shortOption: 'P',
     toggle: true
+  },
+  'wait-after-import': {
+    name: 'Wait N seconds after importing proxy before deploying',
+    shortOption: 'W',
+    required: false
   }
 });
 module.exports.descriptor = descriptor;
@@ -84,7 +89,18 @@ module.exports.format = function(r) {
   return result;
 };
 
+
 module.exports.run = function(opts, cb) {
+  // Setup Delay for after import if set
+  opts.waitAfterImportDelay = 0;
+  if (opts['wait-after-import'] !== undefined) {
+    opts.waitAfterImportDelay = parseInt(opts['wait-after-import']);
+    if (isNaN(opts.waitAfterImportDelay)) {
+      console.error('invalid int for wait-after-import');
+      process.exit(1);
+    }
+  }
+  
   if (!opts.directory) {
     opts.directory = process.cwd();
   }
@@ -679,5 +695,8 @@ function deployProxy(opts, request, done) {
     tasks[env] = deployToEnvironment.bind(this, env);
   });
 
-  async.parallel(tasks, done);
+  if (opts.verbose) { console.log('Delaying deployment for %d seconds', opts.waitAfterImportDelay); }
+  setTimeout(function () {
+      async.parallel(tasks, done);
+  }, opts.waitAfterImportDelay*1000);
 }

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -57,6 +57,11 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Upload Modules',
     shortOption: 'U',
     toggle: true
+  },
+  'wait-after-import': {
+    name: 'Wait N seconds after importing proxy before deploying',
+    shortOption: 'W',
+    required: false
   }
 });
 module.exports.descriptor = descriptor;
@@ -70,6 +75,17 @@ module.exports.format = function(r) {
 };
 
 module.exports.run = function(opts, cb) {
+  // Setup Delay for after import if set
+  opts.waitAfterImportDelay = 0;
+  if (opts['wait-after-import'] !== undefined) {
+    opts.waitAfterImportDelay = parseInt(opts['wait-after-import']);
+    if (isNaN(opts.waitAfterImportDelay)) {
+      console.error('invalid int for wait-after-import');
+      process.exit(1);
+    }
+  }
+
+  
   if (!opts.directory) {
     opts.directory = process.cwd();
   }
@@ -660,5 +676,8 @@ function deployProxy(opts, request, done) {
     tasks[env] = deployToEnvironment.bind(this, env);
   });
 
-  async.parallel(tasks, done);
+  if (opts.verbose) { console.log('Delaying deployment for %d seconds', opts.waitAfterImportDelay); }
+  setTimeout(function () {
+    async.parallel(tasks, done);
+  }, opts.waitAfterImportDelay*1000);
 }


### PR DESCRIPTION
Added `wait-after-import (-W)` option to `deploynodeapp` and `deployproxy`.

Added optional delay after importing proxy delays before preforming
the deployment step.