### PR TITLE
add --production flag to deploynodeapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ for organization name, all of which are required.
 `--resolve-modules   -R`  
 (optional) If the API proxy includes Node.js modules (e.g., in a `node_modules` directory), this option updates them on Apigee Edge without uploading them from your system. Basically, it's like running "npm install" on Apigee Edge in the root directory of the API proxy bundle.  
 
+`--production`
+(optional) Indicates if Apigee Edge should use the `--production` flag during `npm install`. Defaults to `true`, example of disabling the flag would be `--production false`.
+
 `--upload-modules    -U`  
 (optional) If specified, uploads Node.js modules from your system to Apigee Edge rather than resolving the modules directly on Apigee Edge (the default behavior).
 

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -77,6 +77,10 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Wait N seconds after importing proxy before deploying',
     shortOption: 'W',
     required: false
+  },
+  'production': {
+    name: 'Run resolve modules with npm install --production, default true',
+    required: false
   }
 });
 module.exports.descriptor = descriptor;
@@ -594,18 +598,20 @@ function runNpm(opts, request, done) {
       console.log('Running "npm install" at Apigee. This may take several minutes.');
     }
 
-    var body = {
-      command: 'install'
-    };
+    var installURI = util.format('%s/v1/o/%s/apis/%s/revisions/%d/npm?command=install',
+    opts.baseuri, opts.organization, opts.api, opts.deploymentVersion)
+
+    if (opts.production === 'false') {
+      installURI = util.format("%s&production=false", installURI)
+    }
+
     if (opts.debug) {
-      body.verbose = true;
+      installURI = util.format("%s&verbose=true", installURI)
     }
 
     request({
-      uri: util.format('%s/v1/o/%s/apis/%s/revisions/%d/npm',
-             opts.baseuri, opts.organization, opts.api, opts.deploymentVersion),
+      uri: installURI,
       method: 'POST',
-      form: body,
       headers: {
         'Accept': 'text/plain'
       },


### PR DESCRIPTION
add `--production` flag that toggles the use of `--production` when resolving modules in Apigee

Fixes #31 