### PR TITLE
return result in deployProxy including not deployed result

### DIFF
--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -148,8 +148,22 @@ module.exports.run = function(opts, cb) {
             cb(undefined, {});
           }
         },
-        cb);
-    });
+        function(err, result){
+          // if no results then probably not deployed so return info saying that
+          if (result.length === 0) {
+              result = [
+            {
+              revision : opts.deploymentVersion,
+              name : opts.api,
+              environment: 'n/a',
+              state : 'not deployed to environment'
+            }
+          ]
+          }
+          if (opts.debug) { console.log('returning result: %j', result); }
+          cb(err, result);
+      });
+  });
 };
 
 function checkBasePath(opts, cb) {


### PR DESCRIPTION
This change returns deployment information when deployProxy is called so caller can work out which revision was uploaded, where it was deployed to etc.   

It also includes a 'not deployed' information when proxy is uploaded but not deployed