### PR TITLE
deploy commands return basic info after import-only

### DIFF
--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -17,6 +17,7 @@ var ziputils = require('../ziputils');
 var parseDeployments = require('./parsedeployments');
 var fetchproxy = require('./fetchproxy');
 var deployproxy = require('./deployproxy');
+var cleanResults = require('../utils').cleanResults;
 
 var DeploymentDelay = 60;
 var ProxyBase = 'apiproxy';
@@ -164,7 +165,14 @@ module.exports.run = function(opts, cb) {
       ],
       function(err, results) {
         if (err) { return cb(err); }
+
+        results = cleanResults(results);
+
         if (opts.debug) { console.log('results: %j', results); }
+
+        if (opts['import-only']) {
+          return cb(undefined, results)
+        }
 
         async.map(_.values(results[results.length - 1]),
           function(result, cb) {
@@ -641,7 +649,12 @@ function deployProxy(opts, request, done) {
     if (opts.verbose) {
       console.log('Not deploying the proxy right now');
     }
-    done();
+    done(undefined, {
+      name: opts.api,
+      revision: opts.deploymentVersion,
+      state: 'undeployed',
+      basePath: opts['base-path']
+    });
     return;
   }
 

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -14,6 +14,7 @@ var fsutils = require('../fsutils');
 var options = require('../options');
 var ziputils = require('../ziputils');
 var parseDeployments = require('./parsedeployments');
+var cleanResults = require('../utils').cleanResults;
 
 var ProxyBase = 'apiproxy';
 var XmlExp = /(.+)\.xml$/i;
@@ -127,7 +128,16 @@ module.exports.run = function(opts, cb) {
     ],
     function(err, results) {      
       if (err) { return cb(err); }
+
+      // clean out all null result values
+      results = cleanResults(results);
+
       if (opts.debug) { console.log('results: %j', results); }
+
+      // don't attempt to "parse" an undeployed proxy, just return basic info
+      if (opts['import-only']) {
+        return cb(undefined, results);
+      }
 
       async.map(_.values(results[results.length - 1]),
         function(result, cb) {
@@ -617,7 +627,15 @@ function deployProxy(opts, request, done) {
     if (opts.verbose) {
       console.log('Not deploying the proxy right now');
     }
-    done();
+    
+    // return some basic info about the proxy
+    done(undefined, {
+      name: opts.api,
+      revision: opts.deploymentVersion,
+      state: 'undeployed',
+      basePath: opts['base-path']
+    });
+
     return;
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,14 @@
+/* jshint node: true  */
+'use strict';
+
+module.exports.cleanResults = function(results) {
+    var tempResults = [];
+    
+    for(var i = 0; i < results.length; i++) {
+        if (results[i] !== null && results[i] !== undefined) {
+            tempResults.push(results[i])
+        }
+    }
+
+    return tempResults
+}


### PR DESCRIPTION
* `deployproxy` and `deploynodeapp` both return basic proxy info when using the `import-only` option 
* results are cleaned of nulls before printing

Fix #93 