### PR TITLE
b/99 - Pinned request dep to v2.81 to fix node v0.10 and v0.12 issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,21 +23,22 @@
     "async": "^1.4.2",
     "body-parser": "^1.14.0",
     "cli-table": "^0.3.0",
+    "fs-extra": "^4.0.2",
     "mustache": "^2.1.3",
+    "netrc": "^0.1.3",
     "node-unzip-2": "^0.2.1",
     "node-zip": "^1.1.1",
-    "tar-fs": "^1.16.0",
-    "fs-extra": "^4.0.2",
+    "q": "^1.5.1",
     "read": "^1.0.7",
-    "request": "^2.63.0",
+    "request": "~2.81.0",
+    "tar-fs": "^1.16.0",
     "tmp": "^0.0.27",
-    "underscore": "^1.8.3",
-    "netrc": "^0.1.3",
-    "q": "*"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "connect": "^3.4.0",
-    "express": "^4.13.3"
+    "express": "^4.13.3",
+    "mocha": "^3.5.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #99 and #84 