### PR TITLE
Fix ignored approvalType argument for createproduct command

### DIFF
--- a/lib/commands/createproduct.js
+++ b/lib/commands/createproduct.js
@@ -73,8 +73,8 @@ function createProduct(opts,request,done){
 	product.displayName = opts.productName
 	product.description = opts.productDesc
 	if(opts.approvalType){
-    product.approvalType = opts.approvalType
-  }
+		product.approvalType = opts.approvalType
+	}
 	product.proxies = []
 	if(opts.proxies){
 		var split = opts.proxies.split(',')

--- a/lib/commands/createproduct.js
+++ b/lib/commands/createproduct.js
@@ -73,13 +73,8 @@ function createProduct(opts,request,done){
 	product.displayName = opts.productName
 	product.description = opts.productDesc
 	if(opts.approvalType){
-<<<<<<< HEAD
-		product.approvalType = opts.approvalType
-	}
-=======
     product.approvalType = opts.approvalType
   }
->>>>>>> f6a10f3... Fixed ignored approvalType argument for createproduct command
 	product.proxies = []
 	if(opts.proxies){
 		var split = opts.proxies.split(',')

--- a/lib/commands/createproduct.js
+++ b/lib/commands/createproduct.js
@@ -73,8 +73,13 @@ function createProduct(opts,request,done){
 	product.displayName = opts.productName
 	product.description = opts.productDesc
 	if(opts.approvalType){
+<<<<<<< HEAD
 		product.approvalType = opts.approvalType
 	}
+=======
+    product.approvalType = opts.approvalType
+  }
+>>>>>>> f6a10f3... Fixed ignored approvalType argument for createproduct command
 	product.proxies = []
 	if(opts.proxies){
 		var split = opts.proxies.split(',')

--- a/lib/commands/createproduct.js
+++ b/lib/commands/createproduct.js
@@ -9,14 +9,14 @@ var options = require('../options');
 
 var descriptor = defaults.defaultDescriptor({
   'productName': {
-    name: 'Product Name',    
+    name: 'Product Name',
     required: true
   },
   'productDesc': {
   	name: 'Description'
   },
   'proxies': {
-    name: 'API Proxies',    
+    name: 'API Proxies',
     required: true
   },
   'environments':{
@@ -28,7 +28,7 @@ var descriptor = defaults.defaultDescriptor({
   	required: true
   },
   'quota' : {
-  	name: 'Quota',  	
+  	name: 'Quota',
   },
   'quotaInterval':{
   	name: 'Quota Interval'
@@ -37,7 +37,7 @@ var descriptor = defaults.defaultDescriptor({
   	name:'Quota Time Unit'
   },
   'scopes': {
-  	name: "Scope",  	
+  	name: "Scope",
   }
 });
 
@@ -61,17 +61,20 @@ module.exports.run = function(opts, cb) {
     });
 };
 
-function createProduct(opts,request,done){	
+function createProduct(opts,request,done){
 	var product = {
-	  "approvalType": "auto", 
+	  "approvalType": "auto",
 	  "attributes":
-	    [ {"name": "access", "value": "public"} ],	  
+	    [ {"name": "access", "value": "public"} ],
 	  "scopes": []
 	}
-	
+
 	product.name = opts.productName
 	product.displayName = opts.productName
 	product.description = opts.productDesc
+	if(opts.approvalType){
+		product.approvalType = opts.approvalType
+	}
 	product.proxies = []
 	if(opts.proxies){
 		var split = opts.proxies.split(',')
@@ -98,7 +101,7 @@ function createProduct(opts,request,done){
 			}
 		})
 	}
-	product.environments = [] 
+	product.environments = []
 	if(opts.environments){
 		var split = opts.environments.split(',')
 		split.forEach(function(s){
@@ -148,4 +151,3 @@ function createProduct(opts,request,done){
     	}
 	})
 }
-


### PR DESCRIPTION
The createproduct "approvalType" value is ignored even if specified.  This PR adds an additional check to see if the "approvalType" was included, and if so, overrides the default value of "auto".