### PR TITLE
Fix --bundled-dependencies support on Windows

### DIFF
--- a/lib/deploycommon.js
+++ b/lib/deploycommon.js
@@ -317,11 +317,12 @@ module.exports.usePackedSource = function(sourceDir, opts, cb) {
         return cb(err)
       }
   
-      var packageName;
-      var pack = spawn('npm', ['pack'], {cwd: tempDir});
+      var cmd = 'npm' + (process.platform === 'win32' ? '.cmd' : '');
+      var pack = spawn(cmd, ['pack'], {cwd: tempDir});
       pack.on('error', function(err) {
         return cb(err)
       });
+      var packageName;
 
       pack.stdout.on('data', function(data) {
         packageName = data.toString().trim()


### PR DESCRIPTION
On Windows, when spawning children processes for `npm`, you need to use
`npm.cmd` instead of `npm`.  This commit makes it so that the command
used to run `npm pack` works on Windows.

Fixes #120