### PR TITLE
Implementation of #128 (attributes on developer create) and #129 (create key secret)

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,6 +962,12 @@ Create a developer.
     opts.firstName = 'Test'
     opts.lastName = 'Test1'
     opts.userName = 'runningFromTest123'
+    opts.attributes = [
+        {
+            name: "testAttribute",
+            value: "newValue"
+        }
+    ]
 
     sdk.createDeveloper(opts)
       .then(function(result){

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Currently this only affects file uploads in the `deploynodeapp` command. Default
 * [deleteproduct](#deleteproduct)
 * [createapp](#createapp)
 * [deleteapp](#deleteapp)
-* [createkeysecret](#createkeysecret)
+* [createappkey](#createappkey)
 * [createcache](#createcache)
 * [deletecache](#deletecache)
 * [createkvmmap](#createkvmmap)
@@ -1062,9 +1062,9 @@ Delete App in Edge
         //delete app failed
       }) ;
 
-## <a name="createkeysecret"></a>Create Key / Secret
+## <a name="createappkey"></a>Create App Key
 
-Create Key / Secret in Edge
+Create App Key in Edge
 
 #### Example
 
@@ -1074,7 +1074,7 @@ Create Key / Secret in Edge
     opts.appName = APP_NAME;
     opts.apiProducts = PRODUCT_NAME;
     
-    sdk.createKeySecret(opts)
+    sdk.createAppKey(opts)
     .then(function(result){
     //delete app success
     },function(err){

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Currently this only affects file uploads in the `deploynodeapp` command. Default
 * [deleteproduct](#deleteproduct)
 * [createapp](#createapp)
 * [deleteapp](#deleteapp)
+* [createkeysecret](#createkeysecret)
 * [createcache](#createcache)
 * [deletecache](#deletecache)
 * [createkvmmap](#createkvmmap)
@@ -1060,6 +1061,25 @@ Delete App in Edge
       },function(err){
         //delete app failed
       }) ;
+
+## <a name="createkeysecret"></a>Create Key / Secret
+
+Create Key / Secret in Edge
+
+#### Example
+
+    opts.key = APP_KEY;
+    opts.secret = APP_SECRET;
+    opts.developerId = DEVELOPER_EMAIL;
+    opts.appName = APP_NAME;
+    opts.apiProducts = PRODUCT_NAME;
+    
+    sdk.createKeySecret(opts)
+    .then(function(result){
+    //delete app success
+    },function(err){
+    //delete app failed
+    }) ;
 
 ## <a name="createcache"></a>Create Cache
 

--- a/lib/commands/createKeySecret.js
+++ b/lib/commands/createKeySecret.js
@@ -1,0 +1,149 @@
+/* jshint node: true  */
+'use strict';
+
+var util = require('util');
+var _ = require('underscore');
+
+var defaults = require('../defaults');
+var options = require('../options');
+
+var descriptor = defaults.defaultDescriptor({
+  'developerId': {
+    name: 'Developer Id',
+    required: true
+  },
+  'appName': {
+    name: 'App Name',    
+    required: true
+  },
+  'key': {
+    name: 'Client Key',    
+    required: true
+  },
+  'secret': {
+  	name: 'Client secret',
+  	required: true
+  },  
+  'apiProducts' : {
+  	name: 'API Products',
+  	required: true
+  }
+  
+});
+
+module.exports.descriptor = descriptor;
+
+module.exports.run = function(opts, cb) {
+  options.validateSync(opts, descriptor);
+  if (opts.debug) {
+    console.log('createKeySecret: %j', opts);
+  }
+  var request = defaults.defaultRequest(opts);
+  createKeySecret(opts, request, function(err, results) {
+      if (err) {
+        cb(err);
+      } else {
+        if (opts.debug) {
+          console.log('results: %j', results);
+				}
+				associateKeySecret(opts, request, function(err, results) {
+					if (err) {
+						cb(err);
+					} else {
+						if (opts.debug) {
+							console.log('results: %j', results);
+						}
+						cb(undefined, results);        		
+					}
+				});
+      }
+    });
+};
+
+function createKeySecret(opts,request,done){
+	var payload = {
+	  'consumerKey' : opts.key,
+ 		'consumerSecret' : opts.secret
+	}
+
+	var uri = util.format('%s/v1/o/%s/developers/%s/apps/%s/keys/create', opts.baseuri, opts.organization, opts.developerId, opts.appName);
+	request({
+		uri: uri,
+		method:'POST',
+		body: payload,
+		json:true
+	},function(err,res,body){
+		var jsonBody = body
+		if(err){
+			if (opts.debug) {
+		       console.log('Error occured %s', err);
+		    }
+			done(err)
+		}else if (res.statusCode === 201) {
+			if (opts.verbose) {
+       		 console.log('Create KeySecret successful');
+      		}
+		    if (opts.debug) {
+		       console.log('%s', body);
+		    }
+      		done(undefined, jsonBody);
+		}else {
+	      if (opts.verbose) {
+	        console.error('Create KeySecret result: %j', body);
+	      }
+	      var errMsg;
+	      if (jsonBody && (jsonBody.message)) {
+	        errMsg = jsonBody.message;
+	      } else {
+	        errMsg = util.format('Create KeySecret failed with status code %d', res.statusCode);
+	      }
+	      done(new Error(errMsg));
+    	}
+	})
+}
+
+function associateKeySecret(opts,request,done) {
+	var prods = opts.apiProducts;
+	if (typeof prods === 'string') {
+		prods = [prods];
+	}
+
+	var payload = {
+	  'apiProducts' : prods
+	}
+
+	var uri = util.format('%s/v1/o/%s/developers/%s/apps/%s/keys/%s', opts.baseuri, opts.organization, opts.developerId, opts.appName, opts.key);
+	request({
+		uri: uri,
+		method:'POST',
+		body: payload,
+		json:true
+	},function(err,res,body){
+		var jsonBody = body
+		if(err){
+			if (opts.debug) {
+		       console.log('Error occured %s', err);
+		    }
+			done(err)
+		}else if (res.statusCode === 200) {
+			if (opts.verbose) {
+       		 console.log('Associate KeySecret successful');
+      		}
+		    if (opts.debug) {
+		       console.log('%s', body);
+		    }
+      		done(undefined, jsonBody);
+		}else {
+	      if (opts.verbose) {
+	        console.error('Associate KeySecret result: %j', body);
+	      }
+	      var errMsg;
+	      if (jsonBody && (jsonBody.message)) {
+	        errMsg = jsonBody.message;
+	      } else {
+	        errMsg = util.format('Associate KeySecret failed with status code %d', res.statusCode);
+	      }
+	      done(new Error(errMsg));
+    	}
+	})
+}

--- a/lib/commands/createappkey.js
+++ b/lib/commands/createappkey.js
@@ -36,10 +36,10 @@ module.exports.descriptor = descriptor;
 module.exports.run = function(opts, cb) {
   options.validateSync(opts, descriptor);
   if (opts.debug) {
-    console.log('createKeySecret: %j', opts);
+    console.log('createappkey: %j', opts);
   }
   var request = defaults.defaultRequest(opts);
-  createKeySecret(opts, request, function(err, results) {
+  createAppKey(opts, request, function(err, results) {
       if (err) {
         cb(err);
       } else {
@@ -60,7 +60,7 @@ module.exports.run = function(opts, cb) {
     });
 };
 
-function createKeySecret(opts,request,done){
+function createAppKey(opts,request,done){
 	var payload = {
 	  'consumerKey' : opts.key,
  		'consumerSecret' : opts.secret

--- a/lib/commands/createdeveloper.js
+++ b/lib/commands/createdeveloper.js
@@ -22,6 +22,10 @@ var descriptor = defaults.defaultDescriptor({
   'userName':{
   	name: 'User Name',
   	required: true
+  },
+  'attributes':{
+  	name: 'Attributes',
+  	required: false
   }
 });
 
@@ -51,6 +55,10 @@ function createDeveloper(opts,request,done){
  		"firstName" : opts.firstName,
  		"lastName" : opts.lastName,
  		"userName" : opts.userName  
+	}
+
+	if (opts.attributes) {
+		developer.attributes = opts.attributes;
 	}
 
 	var uri = util.format('%s/v1/o/%s/developers', opts.baseuri, opts.organization);

--- a/lib/promisesdk.js
+++ b/lib/promisesdk.js
@@ -211,6 +211,13 @@ ApigeeTool.deployExistingRevision = function(opts) {
   return cb.promise
 }
 
+ApigeeTool.createKeySecret = function(opts) {
+  var cb = q.defer()
+  var cmd = require('./commands/createKeySecret');
+  runCommand(cmd, opts, cb);
+  return cb.promise
+}
+
 function runCommand(cmd, opts, cb) {
   options.validate(opts, cmd.descriptor, function(err) {
     if (err) {

--- a/lib/promisesdk.js
+++ b/lib/promisesdk.js
@@ -211,9 +211,9 @@ ApigeeTool.deployExistingRevision = function(opts) {
   return cb.promise
 }
 
-ApigeeTool.createKeySecret = function(opts) {
+ApigeeTool.createAppKey = function(opts) {
   var cb = q.defer()
-  var cmd = require('./commands/createKeySecret');
+  var cmd = require('./commands/createappkey');
   runCommand(cmd, opts, cb);
   return cb.promise
 }


### PR DESCRIPTION
Added the ability to set custom attributes when creating a developer.
Added the ability to set a custom key / secret for dev app against specific products.  This functionality is via sdk only.