### PR TITLE
Common switch support for mutual auth Apigee endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ this tool:
 Multiple file names may be comma-separated. Use this to communicate with an installation
 of Apigee Edge that uses a custom certificate for API calls.
 
+`--keyfile -K`
+(optional) The name of the PEM file that represents the private key in a mutual auth connection.
+
+`--certfile -C`
+(optional) The name of the PEM file that represents the certificate in a mutual auth connection.
+
 `--debug -D`
 (optional) Prints additional information about the deployment, including router and message processor IDs.
 

--- a/lib/commands/fetchproxy.js
+++ b/lib/commands/fetchproxy.js
@@ -60,7 +60,7 @@ module.exports.run = function(opts, cb) {
         console.log ( 'Received: ' + res.statusCode + ' the following headers: ' + JSON.stringify(res.headers) );
       }
       if (res.statusCode !== 200) {
-        cb(new Error(util.format('Received error %d when fetching proxy: %s',
+        cb(new Error(util.format('Received error %d when fetching proxy: %j',
                     res.statusCode, body)));
       } else {
         fs.writeFile(f, body, 'binary', function(err) {

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -76,6 +76,14 @@ var DefaultDescriptor = {
     name: 'CA file',
     shortOption: 'c'
   },
+  keyfile: {
+    name: 'Key file',
+    shortOption: 'K'
+  },
+  certfile: {
+    name: 'Cert file',
+    shortOption: 'C'
+  },
   insecure: {
     name: 'insecure',
     shortOption: 'k',
@@ -187,6 +195,14 @@ module.exports.defaultRequest = function(opts) {
     });
 
     ro.agentOptions.ca = ca;
+  }
+
+  if (opts.keyfile) {
+    ro.key = fs.readFileSync(opts.keyfile);
+  }
+
+  if (opts.certfile) {
+    ro.cert = fs.readFileSync(opts.certfile);
   }
 
   if (opts.insecure) {


### PR DESCRIPTION
Our company has established endpoints with Apigee that require a mutual auth connection, so that those endpoints are only exposed internally from our corporate network.  In order to use cloud-based DevOps tools to manage Apigee code/objects, we need to be able to make requests from the apigeetool using mutual auth; therefore I've extended the command switches to accept the key/cert file names and request options (ro) defaults to read and apply the file input streams to the key and cert properties of the request object.