### PR TITLE
Handle json.parse failing in deployProxy

### DIFF
--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -606,9 +606,10 @@ function uploadProxies(opts, request, done) {
           if (opts.verbose) {
             console.error('Deployment result: %j', body);
           }
+          var jsonBody;
+          var errMsg;
           try {
-            var jsonBody = JSON.parse(body);
-            var errMsg;
+            jsonBody = JSON.parse(body);
             if (jsonBody && (jsonBody.message)) {
               errMsg = jsonBody.message;
             } else {


### PR DESCRIPTION
Sometimes the returned response is a 504 with an HTML body, and so `JSON.parse` fails -- put that in a try block and call `itemDone` with the parse error if this situation occurs.