### PR TITLE
Added additional params for createcache. Allows description and expiry settings to be passed as arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ Adds an entry of name:value to the named map in the Apigee KVM.
 
 Add entry to KVM with name "test1" and value "value1"
 
-    apigeetool addEntryToKVM -u sdoe@example.com -o sdoe -e test --mapName test-map --entryName test1 --entryValue value1
+    apigeetool addEntryToKVM -u sdoe@example.com -o sdoe -e test --mapName test-map --entryName test1 --entryValue value1 --publicCloudScopedKVM true
 
 #### Required parameters
 
@@ -788,6 +788,9 @@ for organization name, all of which are required.
 
 `--entryValue`
 (required) The value of the entry to be created.
+
+`--publicCloudScopedKVM`
+(optional) true is apigee edge is deployed as public cloud. false if deployed on private cloud Default value is true, deployed as public cloud.
 
 #### Optional parameters
 

--- a/README.md
+++ b/README.md
@@ -936,8 +936,9 @@ Creates a Cache with the given name.
 #### Example
 Create Cache map named "test-cache"
 
-    apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache
+    apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache --description "sample key" --cacheExpiryByDate 12-31-9999
 
+    apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache --description "sample key" --cacheExpiryInSecs 40000
 #### Required parameters
 
 The following parameters are required. However, if any are left unspecified
@@ -951,8 +952,19 @@ for organization name, all of which are required.
 `-z`
 (required) The name of the cache to be created.
 
+`--description`
+(required) The description of the cache to be created.
+
 `--environment -e`
 (required) The environment to target.
+
+Either of the following parameters are required to set the expiry settings
+
+`--cacheExpiryByDate`
+(either-required) Date by which the cache will expire. Date format must be mm-dd-yyyy.
+
+`--cacheExpiryInSecs`
+(either-required) Duration in seconds by which the cache will expire.
 
 ## <a name="Target Server Operations"></a>Target Server Operations
 

--- a/lib/commands/addEntryToKVM.js
+++ b/lib/commands/addEntryToKVM.js
@@ -58,12 +58,12 @@ module.exports.run = function(opts, cb) {
   }
   var payload;
   var uri;
-  if(opts.publicCloudScopedKVM == 'true') {
+  if(String(opts.publicCloudScopedKVM).toLowerCase == 'true') {
     payload  = {
 		  "name" : opts.entryName,
       "value": opts.entryValue		  
     }
-    url = util.format('%s/v1/o/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.mapName);
+    uri = util.format('%s/v1/o/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.mapName);
   
     if (opts.api) {
       uri = util.format('%s/v1/o/%s/apis/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.api, opts.mapName);
@@ -83,7 +83,7 @@ module.exports.run = function(opts, cb) {
         }
       ]
     }
-    url = util.format('%s/v1/o/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.mapName);
+    uri = util.format('%s/v1/o/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.mapName);
   
     if (opts.api) {
       uri = util.format('%s/v1/o/%s/apis/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.api, opts.mapName);

--- a/lib/commands/addEntryToKVM.js
+++ b/lib/commands/addEntryToKVM.js
@@ -58,7 +58,7 @@ module.exports.run = function(opts, cb) {
   }
   var payload;
   var uri;
-  if(String(opts.publicCloudScopedKVM).toLowerCase == 'true') {
+  if(String(opts.publicCloudScopedKVM).toLowerCase() == 'true') {
     payload  = {
 		  "name" : opts.entryName,
       "value": opts.entryValue		  

--- a/lib/commands/addEntryToKVM.js
+++ b/lib/commands/addEntryToKVM.js
@@ -8,6 +8,8 @@ var defaults = require('../defaults');
 var options = require('../options');
 var command_utils = require('./command-utils')
 
+var DefaultPublicCloudScopedKVM = true;
+
 var descriptor = defaults.defaultDescriptor({
   environment: {
     name: 'Environment',
@@ -33,9 +35,15 @@ var descriptor = defaults.defaultDescriptor({
     name:'Entry Value',
     required: true,
     prompt: true
+  },
+  publicCloudScopedKVM: {
+    name:'Public cloud (CPS) scoped KVM'    
   }
-
 });
+
+var DefaultOptions = {
+  publicCloudScopedKVM: DefaultPublicCloudScopedKVM
+};
 
 module.exports.descriptor = descriptor;
 
@@ -43,20 +51,48 @@ module.exports.run = function(opts, cb) {
   if (opts.debug) {
     console.log('addEntryToKVM: %j', opts);
   }  
-  var payload  = {
+  for (var n in DefaultOptions) {
+    if(!opts[n]) {
+      opts[n] = DefaultOptions[n];
+    }
+  }
+  var payload;
+  var uri;
+  if(opts.publicCloudScopedKVM == 'true') {
+    payload  = {
 		  "name" : opts.entryName,
       "value": opts.entryValue		  
-	}
+    }
+    url = util.format('%s/v1/o/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.mapName);
   
-  var uri = util.format('%s/v1/o/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.mapName);
-  
-  if (opts.api) {
-    uri = util.format('%s/v1/o/%s/apis/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.api, opts.mapName);
-  }
+    if (opts.api) {
+      uri = util.format('%s/v1/o/%s/apis/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.api, opts.mapName);
+    }
 
-  if (opts.environment) {
-    uri = util.format('%s/v1/o/%s/e/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.environment, opts.mapName);
-  }
+    if (opts.environment) {
+      uri = util.format('%s/v1/o/%s/e/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.environment, opts.mapName);
+    }
+
+  } else {
+    payload  = {
+      "name": opts.mapName,
+      "entry": [
+        {
+          "name" : opts.entryName,
+          "value": opts.entryValue		  
+        }
+      ]
+    }
+    url = util.format('%s/v1/o/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.mapName);
+  
+    if (opts.api) {
+      uri = util.format('%s/v1/o/%s/apis/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.api, opts.mapName);
+    }
+
+    if (opts.environment) {
+      uri = util.format('%s/v1/o/%s/e/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.environment, opts.mapName);
+    }
+  }  
   
 	var requestOpts = {
 		uri: uri,

--- a/lib/commands/createcache.js
+++ b/lib/commands/createcache.js
@@ -17,7 +17,20 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Cache Resource',
     shortOption: 'z',
     required: true
-  }
+  },
+  description: {
+    name: 'Cache description',    
+    required: true,
+    prompt: true
+  },
+  cacheExpiryByDate:{
+    name: 'Cache expiration by date (mm-dd-yyyy)',    
+    required: false
+  },
+  cacheExpiryInSecs:{
+    name: 'Cache expiration in seconds',    
+    required: false
+  }  
 });
 
 module.exports.descriptor = descriptor;
@@ -45,15 +58,9 @@ function createCache(opts, request, done){
         "compression" : {
           "minimumSizeInKB" : 512
         },
-        "description" : "Store Response",
+        "description" : opts.description,
         "diskSizeInMB" : 1024,
-        "distributed" : true,
-        "expirySettings" : {
-          "expiryDate" : {
-            "value" : "12-31-9999"
-          },
-          "valuesNull" : false
-        },
+        "distributed" : true,        
         "inMemorySizeInKB" : 1024,
         "maxElementsInMemory" : 100,
         "maxElementsOnDisk" : 100,
@@ -63,6 +70,24 @@ function createCache(opts, request, done){
         "skipCacheIfElementSizeInKBExceeds" : 512
       }
 
+  var expirySettings = {};
+  if(opts.cacheExpiryByDate){
+    expirySettings = {
+      "expiryDate" : {
+        "value" : opts.cacheExpiryByDate
+      },
+      "valuesNull" : false
+    }
+  } else if(opts.cacheExpiryInSecs){
+    expirySettings = {
+      "timeoutInSec": {
+        "value": opts.cacheExpiryInSecs
+      },
+      "valuesNull": false
+    }
+  }   
+  createCachePayload.expirySettings = expirySettings;
+  
   var uri = util.format('%s/v1/o/%s/e/%s/caches', opts.baseuri, opts.organization, opts.environment);
   request({
     uri: uri,


### PR DESCRIPTION
Currently description and expiry settings arguments are hard-coded for createcache command in the code. PR changes is to allow description and expiry settings to be passed as arguments for createcache command.

Fix for issues
Issue [174](https://github.com/apigee/apigeetool-node/issues/174)
Changes are tested with sample commands
> apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache --description "sample key" --cacheExpiryByDate 12-31-9999

> apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache --description "sample key" --cacheExpiryInSecs 40000

Issue [114](https://github.com/apigee/apigeetool-node/issues/114)
ApigeeTool is failing with non-cps orgs but passing in CPS orgs. Allows public cloud enabled flag to be passed as argument to support both cps and non-cps orgs.