### PR TITLE
Added additional params for createcache. Allows description and expiry settings to be passed as arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,8 +936,10 @@ Creates a Cache with the given name.
 #### Example
 Create Cache map named "test-cache"
 
-    apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache
+    apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache --description "sample key" --cacheExpiryByDate 12-31-9999
 
+    apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache --description "sample key" --cacheExpiryInSecs 40000
+    
 #### Required parameters
 
 The following parameters are required. However, if any are left unspecified
@@ -951,8 +953,19 @@ for organization name, all of which are required.
 `-z`
 (required) The name of the cache to be created.
 
+`--description`
+(required) The description of the cache to be created.
+
 `--environment -e`
 (required) The environment to target.
+
+Either of the following parameters are required to set the expiry settings
+
+`--cacheExpiryByDate`
+(either-required) Date by which the cache will expire. Date format must be mm-dd-yyyy.
+
+`--cacheExpiryInSecs`
+(either-required) Duration in seconds by which the cache will expire.
 
 ## <a name="Target Server Operations"></a>Target Server Operations
 

--- a/README.md
+++ b/README.md
@@ -936,10 +936,12 @@ Creates a Cache with the given name.
 #### Example
 Create Cache map named "test-cache"
 
-    apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache --description "sample key" --cacheExpiryByDate 12-31-9999
-
-    apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache --description "sample key" --cacheExpiryInSecs 40000
+    apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache 
     
+Create Cache map named "test-cache" (with description and expiry)
+
+    apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache --description "sample key" --cacheExpiryInSecs 40000    
+
 #### Required parameters
 
 The following parameters are required. However, if any are left unspecified
@@ -953,19 +955,17 @@ for organization name, all of which are required.
 `-z`
 (required) The name of the cache to be created.
 
-`--description`
-(required) The description of the cache to be created.
-
 `--environment -e`
 (required) The environment to target.
 
-Either of the following parameters are required to set the expiry settings
+`--description`
+(optional) The description of the cache to be created.
 
 `--cacheExpiryByDate`
-(either-required) Date by which the cache will expire. Date format must be mm-dd-yyyy.
+(optional) Date by which the cache will expire. Date format must be mm-dd-yyyy.
 
 `--cacheExpiryInSecs`
-(either-required) Duration in seconds by which the cache will expire.
+(optional) Duration in seconds by which the cache will expire.
 
 ## <a name="Target Server Operations"></a>Target Server Operations
 

--- a/lib/commands/createcache.js
+++ b/lib/commands/createcache.js
@@ -20,8 +20,7 @@ var descriptor = defaults.defaultDescriptor({
   },
   description: {
     name: 'Cache description',    
-    required: true,
-    prompt: true
+    required: false    
   },
   cacheExpiryByDate:{
     name: 'Cache expiration by date (mm-dd-yyyy)',    
@@ -58,9 +57,15 @@ function createCache(opts, request, done){
         "compression" : {
           "minimumSizeInKB" : 512
         },
-        "description" : opts.description,
+        "description" : opts.description ? opts.description : "Store Response",
         "diskSizeInMB" : 1024,
-        "distributed" : true,        
+        "distributed" : true,  
+        "expirySettings" : {
+          "expiryDate" : {
+            "value" : "12-31-9999"
+          },
+          "valuesNull" : false
+        },      
         "inMemorySizeInKB" : 1024,
         "maxElementsInMemory" : 100,
         "maxElementsOnDisk" : 100,
@@ -69,24 +74,24 @@ function createCache(opts, request, done){
         "persistent" : true,
         "skipCacheIfElementSizeInKBExceeds" : 512
       }
-
-  var expirySettings = {};
+  
   if(opts.cacheExpiryByDate){
-    expirySettings = {
+    var expirySettings = {
       "expiryDate" : {
         "value" : opts.cacheExpiryByDate
       },
       "valuesNull" : false
     }
+    createCachePayload.expirySettings = expirySettings;
   } else if(opts.cacheExpiryInSecs){
-    expirySettings = {
+    var expirySettings = {
       "timeoutInSec": {
         "value": opts.cacheExpiryInSecs
       },
       "valuesNull": false
     }
-  }   
-  createCachePayload.expirySettings = expirySettings;
+    createCachePayload.expirySettings = expirySettings;
+  }     
   
   var uri = util.format('%s/v1/o/%s/e/%s/caches', opts.baseuri, opts.organization, opts.environment);
   request({

--- a/lib/commands/createcache.js
+++ b/lib/commands/createcache.js
@@ -19,17 +19,17 @@ var descriptor = defaults.defaultDescriptor({
     required: true
   },
   description: {
-    name: 'Cache description',    
-    required: false    
+    name: 'Cache description',
+    required: false
   },
   cacheExpiryByDate:{
-    name: 'Cache expiration by date (mm-dd-yyyy)',    
+    name: 'Cache expiration by date (mm-dd-yyyy)',
     required: false
   },
   cacheExpiryInSecs:{
-    name: 'Cache expiration in seconds',    
+    name: 'Cache expiration in seconds',
     required: false
-  }  
+  }
 });
 
 module.exports.descriptor = descriptor;
@@ -77,15 +77,11 @@ function createCache(opts, request, done){
   
   if(opts.cacheExpiryByDate){
     createCachePayload.expirySettings.expiryDate.value = opts.cacheExpiryByDate;
-  } else if(opts.cacheExpiryInSecs){
-    var expirySettings = {
-      "timeoutInSec": {
-        "value": opts.cacheExpiryInSecs
-      },
-      "valuesNull": false
-    }
-    createCachePayload.expirySettings = expirySettings;
-  }     
+  }
+  if(opts.cacheExpiryInSecs){
+    createCachePayload.expirySettings.timeoutInSec = {};
+    createCachePayload.expirySettings.timeoutInSec.value = opts.cacheExpiryInSecs;
+  }
   
   var uri = util.format('%s/v1/o/%s/e/%s/caches', opts.baseuri, opts.organization, opts.environment);
   request({

--- a/lib/commands/createcache.js
+++ b/lib/commands/createcache.js
@@ -17,7 +17,20 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Cache Resource',
     shortOption: 'z',
     required: true
-  }
+  },
+  description: {
+    name: 'Cache description',    
+    required: true,
+    prompt: true
+  },
+  cacheExpiryByDate:{
+    name: 'Cache expiration by date (mm-dd-yyyy)',    
+    required: false
+  },
+  cacheExpiryInSecs:{
+    name: 'Cache expiration in seconds',    
+    required: false
+  }  
 });
 
 module.exports.descriptor = descriptor;
@@ -45,15 +58,9 @@ function createCache(opts, request, done){
         "compression" : {
           "minimumSizeInKB" : 512
         },
-        "description" : "Store Response",
+        "description" : opts.description,
         "diskSizeInMB" : 1024,
-        "distributed" : true,
-        "expirySettings" : {
-          "expiryDate" : {
-            "value" : "12-31-9999"
-          },
-          "valuesNull" : false
-        },
+        "distributed" : true,        
         "inMemorySizeInKB" : 1024,
         "maxElementsInMemory" : 100,
         "maxElementsOnDisk" : 100,
@@ -63,6 +70,24 @@ function createCache(opts, request, done){
         "skipCacheIfElementSizeInKBExceeds" : 512
       }
 
+  var expirySettings = {};
+  if(opts.cacheExpiryByDate){
+    expirySettings = {
+      "expiryDate" : {
+        "value" : opts.cacheExpiryByDate
+      },
+      "valuesNull" : false
+    }
+  } else if(opts.cacheExpiryInSecs){
+    expirySettings = {
+      "timeoutInSec": {
+        "value": opts.cacheExpiryInSecs
+      },
+      "valuesNull": false
+    }
+  }   
+  createCachePayload.expirySettings = expirySettings;
+  
   var uri = util.format('%s/v1/o/%s/e/%s/caches', opts.baseuri, opts.organization, opts.environment);
   request({
     uri: uri,

--- a/lib/commands/createcache.js
+++ b/lib/commands/createcache.js
@@ -79,8 +79,9 @@ function createCache(opts, request, done){
     createCachePayload.expirySettings.expiryDate.value = opts.cacheExpiryByDate;
   }
   if(opts.cacheExpiryInSecs){
-    createCachePayload.expirySettings.timeoutInSec = {};
-    createCachePayload.expirySettings.timeoutInSec.value = opts.cacheExpiryInSecs;
+    createCachePayload.expirySettings.timeoutInSec = {
+      value : opts.cacheExpiryInSecs
+    }
   }
   
   var uri = util.format('%s/v1/o/%s/e/%s/caches', opts.baseuri, opts.organization, opts.environment);

--- a/lib/commands/createcache.js
+++ b/lib/commands/createcache.js
@@ -59,13 +59,13 @@ function createCache(opts, request, done){
         },
         "description" : opts.description ? opts.description : "Store Response",
         "diskSizeInMB" : 1024,
-        "distributed" : true,  
+        "distributed" : true,
         "expirySettings" : {
           "expiryDate" : {
             "value" : "12-31-9999"
           },
           "valuesNull" : false
-        },      
+        },
         "inMemorySizeInKB" : 1024,
         "maxElementsInMemory" : 100,
         "maxElementsOnDisk" : 100,
@@ -76,13 +76,7 @@ function createCache(opts, request, done){
       }
   
   if(opts.cacheExpiryByDate){
-    var expirySettings = {
-      "expiryDate" : {
-        "value" : opts.cacheExpiryByDate
-      },
-      "valuesNull" : false
-    }
-    createCachePayload.expirySettings = expirySettings;
+    createCachePayload.expirySettings.expiryDate.value = opts.cacheExpiryByDate;
   } else if(opts.cacheExpiryInSecs){
     var expirySettings = {
       "timeoutInSec": {

--- a/lib/commands/createcache.js
+++ b/lib/commands/createcache.js
@@ -22,11 +22,11 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Cache description',
     required: false
   },
-  cacheExpiryByDate:{
+  cacheExpiryByDate: {
     name: 'Cache expiration by date (mm-dd-yyyy)',
     required: false
   },
-  cacheExpiryInSecs:{
+  cacheExpiryInSecs: {
     name: 'Cache expiration in seconds',
     required: false
   }
@@ -80,7 +80,7 @@ function createCache(opts, request, done){
   }
   if(opts.cacheExpiryInSecs){
     createCachePayload.expirySettings.timeoutInSec = {
-      value : opts.cacheExpiryInSecs
+      value: opts.cacheExpiryInSecs
     }
   }
   

--- a/remotetests/remotetest.js
+++ b/remotetests/remotetest.js
@@ -17,6 +17,7 @@ var HOSTED_TARGETS_PROXY_NAME = 'cli-hosted-targets-test';
 var CACHE_RESOURCE_NAME='apigee-cli-remotetests-cache1';
 var CACHE_RESOURCE_WITH_EXPIRY_NAME='apigee-cli-remotetests-cache2';
 var CACHE_RESOURCE_WITH_EXPIRY_DESCRIPTION='sample key';
+var CACHE_RESOURCE_WITH_EXPIRY_DATE='31-12-2021';
 var CACHE_RESOURCE_WITH_EXPIRY_TIMEOUT='5000';
 var PROXY_BASE_PATH = '/apigee-cli-test-employees';
 var APIGEE_PRODUCT_NAME = 'TESTPRODUCT';
@@ -889,7 +890,33 @@ describe('Caches', function() { //  it
     });
   });
 
-  it('Create an Cache Resource with description and expiry',function(done){
+  it('Create an Cache Resource with description and expiry in date',function(done){
+    var opts = baseOpts();
+    opts.cache = CACHE_RESOURCE_WITH_EXPIRY_NAME;
+    opts.description = CACHE_RESOURCE_WITH_EXPIRY_DESCRIPTION;
+    opts.cacheExpiryByDate = CACHE_RESOURCE_WITH_EXPIRY_DATE;
+    apigeetool.createcache(opts,function(err,result) {
+      if (verbose) {
+        console.log('Create Cache result = %j', result);
+      }
+      if (err) {
+        done(err);
+      } else {
+        apigeetool.deletecache(opts,function(delete_err,delete_result) {
+          if (verbose) {
+            console.log('Delete Cache result = %j', delete_result);
+          }
+          if (delete_err) {
+            done(delete_err);
+          } else {
+            done()
+          }
+        });
+      }
+    });
+  });
+
+  it('Create an Cache Resource with description and expiry in secs',function(done){
     var opts = baseOpts();
     opts.cache = CACHE_RESOURCE_WITH_EXPIRY_NAME;
     opts.description = CACHE_RESOURCE_WITH_EXPIRY_DESCRIPTION;
@@ -901,22 +928,43 @@ describe('Caches', function() { //  it
       if (err) {
         done(err);
       } else {
-        done()
+        apigeetool.deletecache(opts,function(delete_err,delete_result) {
+          if (verbose) {
+            console.log('Delete Cache result = %j', delete_result);
+          }
+          if (delete_err) {
+            done(delete_err);
+          } else {
+            done()
+          }
+        });
       }
     });
   });
 
-  it('Delete Cache Resource having with description and expiry',function(done){
+  it('Create an Cache Resource with description and expiry in secs, data',function(done){
     var opts = baseOpts();
     opts.cache = CACHE_RESOURCE_WITH_EXPIRY_NAME;
-    apigeetool.deletecache(opts,function(err,result) {
+    opts.description = CACHE_RESOURCE_WITH_EXPIRY_DESCRIPTION;
+    opts.cacheExpiryByDate = CACHE_RESOURCE_WITH_EXPIRY_DATE;
+    opts.cacheExpiryInSecs = CACHE_RESOURCE_WITH_EXPIRY_TIMEOUT;
+    apigeetool.createcache(opts,function(err,result) {
       if (verbose) {
-        console.log('Delete Cache result = %j', result);
+        console.log('Create Cache result = %j', result);
       }
       if (err) {
         done(err);
       } else {
-        done()
+        apigeetool.deletecache(opts,function(delete_err,delete_result) {
+          if (verbose) {
+            console.log('Delete Cache result = %j', delete_result);
+          }
+          if (delete_err) {
+            done(delete_err);
+          } else {
+            done()
+          }
+        });
       }
     });
   });

--- a/remotetests/remotetest.js
+++ b/remotetests/remotetest.js
@@ -15,6 +15,9 @@ var APIGEE_PROXY_NAME = 'apigee-cli-apigee-test';
 var NODE_PROXY_NAME = 'apigee-cli-node-test';
 var HOSTED_TARGETS_PROXY_NAME = 'cli-hosted-targets-test';
 var CACHE_RESOURCE_NAME='apigee-cli-remotetests-cache1';
+var CACHE_RESOURCE_WITH_EXPIRY_NAME='apigee-cli-remotetests-cache2';
+var CACHE_RESOURCE_WITH_EXPIRY_DESCRIPTION='sample key';
+var CACHE_RESOURCE_WITH_EXPIRY_TIMEOUT='5000';
 var PROXY_BASE_PATH = '/apigee-cli-test-employees';
 var APIGEE_PRODUCT_NAME = 'TESTPRODUCT';
 var APIGEE_PRIVATE_PRODUCT_NAME = 'TESTPRODUCT-private';
@@ -874,6 +877,38 @@ describe('Caches', function() { //  it
   it('Delete Cache Resource',function(done){
     var opts = baseOpts();
     opts.cache = CACHE_RESOURCE_NAME;
+    apigeetool.deletecache(opts,function(err,result) {
+      if (verbose) {
+        console.log('Delete Cache result = %j', result);
+      }
+      if (err) {
+        done(err);
+      } else {
+        done()
+      }
+    });
+  });
+
+  it('Create an Cache Resource with description and expiry',function(done){
+    var opts = baseOpts();
+    opts.cache = CACHE_RESOURCE_WITH_EXPIRY_NAME;
+    opts.description = CACHE_RESOURCE_WITH_EXPIRY_DESCRIPTION;
+    opts.cacheExpiryInSecs = CACHE_RESOURCE_WITH_EXPIRY_TIMEOUT;
+    apigeetool.createcache(opts,function(err,result) {
+      if (verbose) {
+        console.log('Create Cache result = %j', result);
+      }
+      if (err) {
+        done(err);
+      } else {
+        done()
+      }
+    });
+  });
+
+  it('Delete Cache Resource having with description and expiry',function(done){
+    var opts = baseOpts();
+    opts.cache = CACHE_RESOURCE_WITH_EXPIRY_NAME;
     apigeetool.deletecache(opts,function(err,result) {
       if (verbose) {
         console.log('Delete Cache result = %j', result);


### PR DESCRIPTION
Added additional params for createcache commands. Allows description and expiry settings to be passed as arguments.

Currently description and expiry settings arguments are hard-coded for createcache command in the code. PR changes is to allow description and expiry settings to be passed as arguments for createcache command.

Fix for issues
Issue [174](https://github.com/apigee/apigeetool-node/issues/174)
Changes are tested with sample commands
> apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache --description "sample key" --cacheExpiryByDate 12-31-9999

> apigeetool createcache -u sdoe@example.com -o sdoe -e test -z test-cache --description "sample key" --cacheExpiryInSecs 40000
