### PR TITLE
Update URL to be able to use in Apigee X and Hybrid installations

### DIFF
--- a/lib/commands/addEntryToKVM.js
+++ b/lib/commands/addEntryToKVM.js
@@ -48,14 +48,14 @@ module.exports.run = function(opts, cb) {
       "value": opts.entryValue		  
 	}
   
-  var uri = util.format('%s/v1/o/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.mapName);
+  var uri = util.format('%s/v1/organizations/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.mapName);
   
   if (opts.api) {
-    uri = util.format('%s/v1/o/%s/apis/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.api, opts.mapName);
+    uri = util.format('%s/v1/organizations/%s/apis/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.api, opts.mapName);
   }
 
   if (opts.environment) {
-    uri = util.format('%s/v1/o/%s/e/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.environment, opts.mapName);
+    uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s/entries', opts.baseuri, opts.organization, opts.environment, opts.mapName);
   }
   
 	var requestOpts = {

--- a/lib/commands/assignUserRole.js
+++ b/lib/commands/assignUserRole.js
@@ -29,7 +29,7 @@ module.exports.run = function(opts, cb) {
   }
 
   var formData = util.format('id=%s', encodeURIComponent(opts.email));
-  var uri = util.format('%s/v1/o/%s/userroles/%s/users', opts.baseuri, opts.organization, opts.roleName);
+  var uri = util.format('%s/v1/organizations/%s/userroles/%s/users', opts.baseuri, opts.organization, opts.roleName);
   var requestOptions = {
     uri: uri,
     method:'POST',

--- a/lib/commands/attachFlowHook.js
+++ b/lib/commands/attachFlowHook.js
@@ -41,7 +41,7 @@ module.exports.run = function(opts, cb) {
 		payload.sSLInfo = {enabled: true} 
 	}
 
-	var uri = util.format('%s/v1/o/%s/e/%s/flowhooks/%s', opts.baseuri, opts.organization, opts.environment, opts.flowHookName);
+	var uri = util.format('%s/v1/organizations/%s/environments/%s/flowhooks/%s', opts.baseuri, opts.organization, opts.environment, opts.flowHookName);
 	var requestOpts = {
 		uri: uri,
 		method:'POST',

--- a/lib/commands/create-KVM.js
+++ b/lib/commands/create-KVM.js
@@ -42,14 +42,14 @@ module.exports.run = function(opts, cb) {
     encrypted: opts.encrypted
   };
   
-  var uri = util.format('%s/v1/o/%s/keyvaluemaps', opts.baseuri, opts.organization);
+  var uri = util.format('%s/v1/organizations/%s/keyvaluemaps', opts.baseuri, opts.organization);
   
   if (opts.api) {
-    uri = util.format('%s/v1/o/%s/apis/%s/keyvaluemaps', opts.baseuri, opts.organization, opts.api);
+    uri = util.format('%s/v1/organizations/%s/apis/%s/keyvaluemaps', opts.baseuri, opts.organization, opts.api);
   }
   
   if (opts.environment) {
-    uri = util.format('%s/v1/o/%s/e/%s/keyvaluemaps', opts.baseuri, opts.organization, opts.environment);
+    uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps', opts.baseuri, opts.organization, opts.environment);
   }
   
   var requestOpts = {

--- a/lib/commands/create-TargetServer.js
+++ b/lib/commands/create-TargetServer.js
@@ -54,7 +54,7 @@ module.exports.run = function(opts, cb) {
 		payload.sSLInfo = {enabled: true} 
 	}
 
-	var uri = util.format('%s/v1/o/%s/e/%s/targetservers', opts.baseuri, opts.organization, opts.environment);
+	var uri = util.format('%s/v1/organizations/%s/environments/%s/targetservers', opts.baseuri, opts.organization, opts.environment);
 	var requestOpts = {
 		uri: uri,
 		method:'POST',

--- a/lib/commands/createRole.js
+++ b/lib/commands/createRole.js
@@ -28,7 +28,7 @@ module.exports.run = function(opts, cb) {
    ]
   };
   
-  var uri = util.format('%s/v1/o/%s/userroles', opts.baseuri, opts.organization);
+  var uri = util.format('%s/v1/organizations/%s/userroles', opts.baseuri, opts.organization);
   var requestOptions = {
     uri: uri,
     method:'POST',

--- a/lib/commands/createapp.js
+++ b/lib/commands/createapp.js
@@ -74,7 +74,7 @@ function createApp(opts,request,done){
 		})
 	}
 
-	var uri = util.format('%s/v1/o/%s/developers/%s/apps', opts.baseuri, opts.organization,opts.email);
+	var uri = util.format('%s/v1/organizations/%s/developers/%s/apps', opts.baseuri, opts.organization,opts.email);
 	request({
 		uri: uri,
 		method:'POST',

--- a/lib/commands/createappkey.js
+++ b/lib/commands/createappkey.js
@@ -66,7 +66,7 @@ function createAppKey(opts,request,done){
  		'consumerSecret' : opts.secret
 	}
 
-	var uri = util.format('%s/v1/o/%s/developers/%s/apps/%s/keys/create', opts.baseuri, opts.organization, opts.developerId, opts.appName);
+	var uri = util.format('%s/v1/organizations/%s/developers/%s/apps/%s/keys/create', opts.baseuri, opts.organization, opts.developerId, opts.appName);
 	request({
 		uri: uri,
 		method:'POST',
@@ -112,7 +112,7 @@ function associateKeySecret(opts,request,done) {
 	  'apiProducts' : prods
 	}
 
-	var uri = util.format('%s/v1/o/%s/developers/%s/apps/%s/keys/%s', opts.baseuri, opts.organization, opts.developerId, opts.appName, opts.key);
+	var uri = util.format('%s/v1/organizations/%s/developers/%s/apps/%s/keys/%s', opts.baseuri, opts.organization, opts.developerId, opts.appName, opts.key);
 	request({
 		uri: uri,
 		method:'POST',

--- a/lib/commands/createcache.js
+++ b/lib/commands/createcache.js
@@ -84,7 +84,7 @@ function createCache(opts, request, done){
     }
   }
   
-  var uri = util.format('%s/v1/o/%s/e/%s/caches', opts.baseuri, opts.organization, opts.environment);
+  var uri = util.format('%s/v1/organizations/%s/environments/%s/caches', opts.baseuri, opts.organization, opts.environment);
   request({
     uri: uri,
     method:'POST',

--- a/lib/commands/createdeveloper.js
+++ b/lib/commands/createdeveloper.js
@@ -61,7 +61,7 @@ function createDeveloper(opts,request,done){
 		developer.attributes = opts.attributes;
 	}
 
-	var uri = util.format('%s/v1/o/%s/developers', opts.baseuri, opts.organization);
+	var uri = util.format('%s/v1/organizations/%s/developers', opts.baseuri, opts.organization);
 	request({
 		uri: uri,
 		method:'POST',

--- a/lib/commands/createproduct.js
+++ b/lib/commands/createproduct.js
@@ -126,7 +126,7 @@ function createProduct(opts,request,done){
 		product.quotaTimeUnit = opts.quotaTimeUnit
 	}
 
-	var uri = util.format('%s/v1/o/%s/apiproducts', opts.baseuri, opts.organization);
+	var uri = util.format('%s/v1/organizations/%s/apiproducts', opts.baseuri, opts.organization);
 	request({
 		uri: uri,
 		method:'POST',

--- a/lib/commands/delete-KVM.js
+++ b/lib/commands/delete-KVM.js
@@ -33,14 +33,14 @@ module.exports.run = function(opts, cb) {
     console.log('deleteKeyVaueMap: %j', opts);
   }  
   
-  var uri = util.format('%s/v1/o/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.mapName);
+  var uri = util.format('%s/v1/organizations/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.mapName);
   
   if (opts.api) {
-    uri = util.format('%s/v1/o/%s/apis/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.api, opts.mapName);
+    uri = util.format('%s/v1/organizations/%s/apis/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.api, opts.mapName);
   }
 
   if (opts.environment) {
-    uri = util.format('%s/v1/o/%s/e/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.environment, opts.mapName);
+    uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.environment, opts.mapName);
   }
   
 	var requestOpts = {

--- a/lib/commands/delete-TargetServer.js
+++ b/lib/commands/delete-TargetServer.js
@@ -28,7 +28,7 @@ module.exports.run = function(opts, cb) {
   if (opts.debug) {
     console.log('deleteTargetServer: %j', opts);
   }
-  var uri = util.format('%s/v1/o/%s/e/%s/targetservers/%s', opts.baseuri, opts.organization, opts.environment,opts.targetServerName);
+  var uri = util.format('%s/v1/organizations/%s/environments/%s/targetservers/%s', opts.baseuri, opts.organization, opts.environment,opts.targetServerName);
   var requestOptions = {
     uri: uri,
     method:'DELETE',

--- a/lib/commands/delete.js
+++ b/lib/commands/delete.js
@@ -70,7 +70,7 @@ function doDelete(opts, request, done) {
     console.log('Deleting %s', opts.api);
   }
 
-  var uri = util.format('%s/v1/o/%s/apis/%s', opts.baseuri, opts.organization, opts.api);
+  var uri = util.format('%s/v1/organizations/%s/apis/%s', opts.baseuri, opts.organization, opts.api);
   if (opts.debug) {
     console.log('Going to send DELETE to %s', uri);
   }

--- a/lib/commands/deleteKVMentry.js
+++ b/lib/commands/deleteKVMentry.js
@@ -36,14 +36,14 @@ module.exports.run = function(opts, cb) {
     console.log('deleteKVMentry: %j', opts);
   }  
   
-	var uri = util.format('%s/v1/o/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.mapName, opts.entryName);
+	var uri = util.format('%s/v1/organizations/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.mapName, opts.entryName);
   
   if (opts.api) {
-    uri = util.format('%s/v1/o/%s/apis/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.api, opts.mapName, opts.entryName);
+    uri = util.format('%s/v1/organizations/%s/apis/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.api, opts.mapName, opts.entryName);
   }
 
   if (opts.environment) {
-    uri = util.format('%s/v1/o/%s/e/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.environment, opts.mapName, opts.entryName);
+    uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.environment, opts.mapName, opts.entryName);
   }
   
 	var requestOpts = {

--- a/lib/commands/deleteRole.js
+++ b/lib/commands/deleteRole.js
@@ -22,7 +22,7 @@ module.exports.run = function(opts, cb) {
   if (opts.debug) {
     console.log('deleteRole: %j', opts);
   }
-  var uri = util.format('%s/v1/o/%s/userroles/%s', opts.baseuri, opts.organization, opts.roleName);
+  var uri = util.format('%s/v1/organizations/%s/userroles/%s', opts.baseuri, opts.organization, opts.roleName);
   var requestOptions = {
     uri: uri,
     method:'DELETE',

--- a/lib/commands/deleteapp.js
+++ b/lib/commands/deleteapp.js
@@ -39,7 +39,7 @@ module.exports.run = function(opts, cb) {
 };
 
 function deleteApp(opts,request,done){
-	var uri = util.format('%s/v1/o/%s/developers/%s/apps/%s', opts.baseuri, opts.organization,opts.email,opts.name);
+	var uri = util.format('%s/v1/organizations/%s/developers/%s/apps/%s', opts.baseuri, opts.organization,opts.email,opts.name);
 	request({
 		uri: uri,
 		method:'DELETE',		

--- a/lib/commands/deletecache.js
+++ b/lib/commands/deletecache.js
@@ -41,7 +41,7 @@ module.exports.run = function(opts, cb) {
 };
 
 function deleteCache(opts, request, done){
-	var uri = util.format('%s/v1/o/%s/e/%s/caches/%s', opts.baseuri, opts.organization, opts.environment,opts.cache);
+	var uri = util.format('%s/v1/organizations/%s/environments/%s/caches/%s', opts.baseuri, opts.organization, opts.environment,opts.cache);
 	request({
 		uri: uri,
 		method:'DELETE',

--- a/lib/commands/deletedeveloper.js
+++ b/lib/commands/deletedeveloper.js
@@ -35,7 +35,7 @@ module.exports.run = function(opts, cb) {
 };
 
 function deleteDeveloper(opts,request,done){
-	var uri = util.format('%s/v1/o/%s/developers/%s', opts.baseuri, opts.organization,opts.email);
+	var uri = util.format('%s/v1/organizations/%s/developers/%s', opts.baseuri, opts.organization,opts.email);
 	request({
 		uri: uri,
 		method:'DELETE',		

--- a/lib/commands/deleteproduct.js
+++ b/lib/commands/deleteproduct.js
@@ -35,7 +35,7 @@ module.exports.run = function(opts, cb) {
 };
 
 function deleteProduct(opts,request,done){	
-	var uri = util.format('%s/v1/o/%s/apiproducts/%s', opts.baseuri, opts.organization,opts.productName);
+	var uri = util.format('%s/v1/organizations/%s/apiproducts/%s', opts.baseuri, opts.organization,opts.productName);
 	request({
 		uri: uri,
 		method:'DELETE',		

--- a/lib/commands/deletesharedflow.js
+++ b/lib/commands/deletesharedflow.js
@@ -70,7 +70,7 @@ function doDelete(opts, request, done) {
     console.log('Deleting %s', opts.name);
   }
 
-  var uri = util.format('%s/v1/o/%s/sharedflows/%s', opts.baseuri, opts.organization, opts.name);
+  var uri = util.format('%s/v1/organizations/%s/sharedflows/%s', opts.baseuri, opts.organization, opts.name);
   if (opts.debug) {
     console.log('Going to send DELETE to %s', uri);
   }

--- a/lib/commands/deployExistingRevision.js
+++ b/lib/commands/deployExistingRevision.js
@@ -83,7 +83,7 @@ function deployProxy(opts, request, done) {
   
     function deployToEnvironment(environment, done) {
   
-      var uri = util.format('%s/v1/o/%s/e/%s/apis/%s/revisions/%d/deployments',
+      var uri = util.format('%s/v1/organizations/%s/environments/%s/apis/%s/revisions/%d/deployments',
         opts.baseuri, opts.organization, environment, opts.api, opts.revision);
       if (opts.debug) { console.log('Going to POST to %s', uri); }
   

--- a/lib/commands/deployhostedtarget.js
+++ b/lib/commands/deployhostedtarget.js
@@ -263,7 +263,7 @@ function getDeploymentInfo(opts, request, done) {
   }
 
   // Find out which revision we should be creating
-  request.get(util.format('%s/v1/o/%s/apis/%s',
+  request.get(util.format('%s/v1/organizations/%s/apis/%s',
                opts.baseuri, opts.organization, opts.api),
   function(err, req, body) {
       if (err) {
@@ -299,7 +299,7 @@ function createTarget(opts, request, done) {
     '<HostedTarget/>' +
     '</TargetEndpoint>', opts);
 
-  var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/targets?name=default',
+  var uri = util.format('%s/v1/organizations/%s/apis/%s/revisions/%d/targets?name=default',
               opts.baseuri, opts.organization, opts.api,
               opts.deploymentVersion);
   if (opts.verbose) {

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -341,7 +341,7 @@ function getDeploymentInfo(opts, request, done) {
   }
 
   // Find out which revision we should be creating
-  request.get(util.format('%s/v1/o/%s/apis/%s',
+  request.get(util.format('%s/v1/organizations/%s/apis/%s',
                opts.baseuri, opts.organization, opts.api),
   function(err, req, body) {
       if (err) {
@@ -379,7 +379,7 @@ function createTarget(opts, request, done) {
     '</ScriptTarget>' +
     '</TargetEndpoint>', opts);
 
-  var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/targets?name=default',
+  var uri = util.format('%s/v1/organizations/%s/apis/%s/revisions/%d/targets?name=default',
               opts.baseuri, opts.organization, opts.api,
               opts.deploymentVersion);
   if (opts.verbose) {
@@ -405,7 +405,7 @@ function runNpm(opts, request, done) {
       console.log('Running "npm install" at Apigee. This may take several minutes.');
     }
 
-    var installURI = util.format('%s/v1/o/%s/apis/%s/revisions/%d/npm?command=install',
+    var installURI = util.format('%s/v1/organizations/%s/apis/%s/revisions/%d/npm?command=install',
     opts.baseuri, opts.organization, opts.api, opts.deploymentVersion)
 
     if (opts.production === 'false') {

--- a/lib/commands/deployproxy.js
+++ b/lib/commands/deployproxy.js
@@ -216,7 +216,7 @@ function getDeploymentInfo(opts, request, done) {
   }
 
   // Find out which revision we should be creating
-  request.get(util.format('%s/v1/o/%s/apis/%s',
+  request.get(util.format('%s/v1/organizations/%s/apis/%s',
                opts.baseuri, opts.organization, opts.api),
   function(err, req, body) {
       if (err) {
@@ -263,7 +263,7 @@ function createApiProxy(opts, request, done) {
     rootDoc = mustache.render('<APIProxy name="{{api}}"/>', opts);
   }
 
-  var uri = util.format('%s/v1/o/%s/apis?action=import&validate=false&name=%s',
+  var uri = util.format('%s/v1/organizations/%s/apis?action=import&validate=false&name=%s',
                     opts.baseuri, opts.organization, opts.api);
   if (opts.debug) {
     console.log('Calling %s', uri);
@@ -321,7 +321,7 @@ function uploadResources(opts, request, done) {
   
   async.eachLimit(entries, opts.asynclimit, function(entry, entryDone) {
     var uri =
-      util.format('%s/v1/o/%s/apis/%s/revisions/%d/resources?type=%s&name=%s',
+      util.format('%s/v1/organizations/%s/apis/%s/revisions/%d/resources?type=%s&name=%s',
                   opts.baseuri, opts.organization, opts.api,
                   opts.deploymentVersion, entry.resourceType, entry.resourceName);
     if(opts['bundled-dependencies'] && (entry.resourceType === 'node' || entry.resourceType === 'hosted')) {
@@ -455,7 +455,7 @@ function uploadPolicies(opts, request, done) {
     if (opts.verbose) {
       console.log('Uploading policy %s', fileName);
     }
-    var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/policies',
+    var uri = util.format('%s/v1/organizations/%s/apis/%s/revisions/%d/policies',
                 opts.baseuri, opts.organization, opts.api,
                 opts.deploymentVersion);
     var postReq = request({
@@ -518,7 +518,7 @@ function uploadTargets(opts, request, done) {
     if (opts.verbose) {
       console.log('Uploading target %s', isXml[1]);
     }
-    var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/targets?name=%s',
+    var uri = util.format('%s/v1/organizations/%s/apis/%s/revisions/%d/targets?name=%s',
                 opts.baseuri, opts.organization, opts.api,
                 opts.deploymentVersion, isXml[1]);
     var postReq = request({
@@ -589,7 +589,7 @@ function uploadProxies(opts, request, done) {
       if (opts.verbose) {
         console.log('Uploading proxy %s', proxyName);
       }
-      var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/proxies?name=%s',
+      var uri = util.format('%s/v1/organizations/%s/apis/%s/revisions/%d/proxies?name=%s',
         opts.baseuri, opts.organization, opts.api,
         opts.deploymentVersion, proxyName);
       var postReq = request({
@@ -648,7 +648,7 @@ function runNpm(opts, request, done) {
     }
 
     request({
-      uri: util.format('%s/v1/o/%s/apis/%s/revisions/%d/npm',
+      uri: util.format('%s/v1/organizations/%s/apis/%s/revisions/%d/npm',
              opts.baseuri, opts.organization, opts.api, opts.deploymentVersion),
       method: 'POST',
       form: body,
@@ -702,7 +702,7 @@ function deployProxy(opts, request, done) {
 
   function deployToEnvironment(environment, done) {
 
-    var uri = util.format('%s/v1/o/%s/e/%s/apis/%s/revisions/%d/deployments',
+    var uri = util.format('%s/v1/organizations/%s/environments/%s/apis/%s/revisions/%d/deployments',
       opts.baseuri, opts.organization, environment, opts.api, opts.deploymentVersion);
     if (opts.debug) { console.log('Going to POST to %s', uri); }
 

--- a/lib/commands/deploysharedflow.js
+++ b/lib/commands/deploysharedflow.js
@@ -134,7 +134,7 @@ function getDeploymentInfo(opts, request, done) {
   }
 
   // Find out which revision we should be creating
-  request.get(util.format('%s/v1/o/%s/sharedflows/%s',
+  request.get(util.format('%s/v1/organizations/%s/sharedflows/%s',
     opts.baseuri, opts.organization, opts.name),
     function (err, req, body) {
       if (err) {
@@ -183,7 +183,7 @@ function createSharedFlowBundle(opts, request, done) {
     rootDoc = mustache.render('<SharedFlowBundle name="{{name}}"/>', opts);
   }
 
-  var uri = util.format('%s/v1/o/%s/sharedflows?action=import&validate=false&name=%s',
+  var uri = util.format('%s/v1/organizations/%s/sharedflows?action=import&validate=false&name=%s',
     opts.baseuri, opts.organization, opts.name);
   if (opts.debug) {
     console.log('Calling %s', uri);
@@ -241,7 +241,7 @@ function uploadResources(opts, request, done) {
 
   async.eachLimit(entries, opts.asynclimit, function (entry, entryDone) {
     var uri =
-      util.format('%s/v1/o/%s/sharedflows/%s/revisions/%d/resources?type=%s&name=%s',
+      util.format('%s/v1/organizations/%s/sharedflows/%s/revisions/%d/resources?type=%s&name=%s',
         opts.baseuri, opts.organization, opts.name,
         opts.deploymentVersion, entry.resourceType, entry.resourceName);
     if (entry.directory) {
@@ -334,7 +334,7 @@ function uploadPolicies(opts, request, done) {
     if (opts.verbose) {
       console.log('Uploading policy %s', fileName);
     }
-    var uri = util.format('%s/v1/o/%s/sharedflows/%s/revisions/%d/policies',
+    var uri = util.format('%s/v1/organizations/%s/sharedflows/%s/revisions/%d/policies',
       opts.baseuri, opts.organization, opts.name,
       opts.deploymentVersion);
     var postReq = request({
@@ -398,7 +398,7 @@ function uploadSharedFlows(opts, request, done) {
     if (opts.verbose) {
       console.log('Uploading sharedflows %s', isXml[1]);
     }
-    var uri = util.format('%s/v1/o/%s/sharedflows/%s/revisions/%d/sharedflows?name=%s',
+    var uri = util.format('%s/v1/organizations/%s/sharedflows/%s/revisions/%d/sharedflows?name=%s',
       opts.baseuri, opts.organization, opts.name,
       opts.deploymentVersion, isXml[1]);
     var postReq = request({
@@ -443,7 +443,7 @@ function deploySharedFlow(opts, request, done) {
 
   function deployToEnvironment(environment, done) {
 
-    var uri = util.format('%s/v1/o/%s/e/%s/sharedflows/%s/revisions/%d/deployments',
+    var uri = util.format('%s/v1/organizations/%s/environments/%s/sharedflows/%s/revisions/%d/deployments',
       opts.baseuri, opts.organization, environment, opts.name, opts.deploymentVersion);
     if (opts.debug) {
       console.log('Going to POST to %s', uri);

--- a/lib/commands/detachFlowHook.js
+++ b/lib/commands/detachFlowHook.js
@@ -32,7 +32,7 @@ module.exports.run = function(opts, cb) {
 		payload.sSLInfo = {enabled: true} 
 	}
 
-	var uri = util.format('%s/v1/o/%s/e/%s/flowhooks/%s', opts.baseuri, opts.organization, opts.environment, opts.flowHookName);
+	var uri = util.format('%s/v1/organizations/%s/environments/%s/flowhooks/%s', opts.baseuri, opts.organization, opts.environment, opts.flowHookName);
 	var requestOpts = {
 		uri: uri,
 		method:'DELETE',

--- a/lib/commands/fetchproxy.js
+++ b/lib/commands/fetchproxy.js
@@ -36,7 +36,7 @@ module.exports.run = function(opts, cb) {
   }
 
   if (opts.api && opts.revision) {
-    uri = util.format('%s/v1/o/%s/apis/%s/revisions/%s?format=bundle',
+    uri = util.format('%s/v1/organizations/%s/apis/%s/revisions/%s?format=bundle',
       opts.baseuri, opts.organization, opts.api, opts.revision);
   } else {
     cb(new Error('org, api and revision must all be specified! ' + JSON.stringify(opts)));

--- a/lib/commands/fetchsharedflow.js
+++ b/lib/commands/fetchsharedflow.js
@@ -38,7 +38,7 @@ module.exports.run = function (opts, cb) {
   }
 
   if (opts.name && opts.revision) {
-    uri = util.format('%s/v1/o/%s/sharedflows/%s/revisions/%s?format=bundle',
+    uri = util.format('%s/v1/organizations/%s/sharedflows/%s/revisions/%s?format=bundle',
       opts.baseuri, opts.organization, opts.name, opts.revision);
   } else {
     cb(new Error('org, sharedflow name, and revision must all be specified! ' + JSON.stringify(opts)));

--- a/lib/commands/get-TargetServer.js
+++ b/lib/commands/get-TargetServer.js
@@ -28,7 +28,7 @@ module.exports.run = function(opts, cb) {
   if (opts.debug) {
     console.log('getTargetServer: %j', opts);
   }
-  var uri = util.format('%s/v1/o/%s/e/%s/targetservers/%s', opts.baseuri, opts.organization, opts.environment,opts.targetServerName);
+  var uri = util.format('%s/v1/organizations/%s/environments/%s/targetservers/%s', opts.baseuri, opts.organization, opts.environment,opts.targetServerName);
   var requestOptions = {
     uri: uri,
     method:'GET',

--- a/lib/commands/getFlowHook.js
+++ b/lib/commands/getFlowHook.js
@@ -32,7 +32,7 @@ module.exports.run = function(opts, cb) {
     payload.sSLInfo = {enabled: true} 
   }
 
-  var uri = util.format('%s/v1/o/%s/e/%s/flowhooks/%s', opts.baseuri, opts.organization, opts.environment, opts.flowHookName);
+  var uri = util.format('%s/v1/organizations/%s/environments/%s/flowhooks/%s', opts.baseuri, opts.organization, opts.environment, opts.flowHookName);
   var requestOpts = {
     uri: uri,
     method:'GET',

--- a/lib/commands/getKVMentry.js
+++ b/lib/commands/getKVMentry.js
@@ -37,14 +37,14 @@ module.exports.run = function(opts, cb) {
     console.log('getKVMentry: %j', opts);
   }
 
-  var uri = util.format('%s/v1/o/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.mapName, opts.entryName);
+  var uri = util.format('%s/v1/organizations/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.mapName, opts.entryName);
   
   if (opts.api) {
-    uri = util.format('%s/v1/o/%s/apis/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.api, opts.mapName, opts.entryName);
+    uri = util.format('%s/v1/organizations/%s/apis/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.api, opts.mapName, opts.entryName);
   }
 
   if (opts.environment) {
-    uri = util.format('%s/v1/o/%s/e/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.environment, opts.mapName, opts.entryName);
+    uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.environment, opts.mapName, opts.entryName);
   }
 
 	var requestOpts = {

--- a/lib/commands/getRole.js
+++ b/lib/commands/getRole.js
@@ -22,7 +22,7 @@ module.exports.run = function(opts, cb) {
   if (opts.debug) {
     console.log('getRole: %j', opts);
   }
-  var uri = util.format('%s/v1/o/%s/userroles/%s', opts.baseuri, opts.organization, opts.roleName);
+  var uri = util.format('%s/v1/organizations/%s/userroles/%s', opts.baseuri, opts.organization, opts.roleName);
   var requestOptions = {
     uri: uri,
     method:'GET',

--- a/lib/commands/getRolePermissions.js
+++ b/lib/commands/getRolePermissions.js
@@ -22,7 +22,7 @@ module.exports.run = function(opts, cb) {
   if (opts.debug) {
     console.log('getRolePermissions: %j', opts);
   }
-  var uri = util.format('%s/v1/o/%s/userroles/%s/permissions', opts.baseuri, opts.organization, opts.roleName);
+  var uri = util.format('%s/v1/organizations/%s/userroles/%s/permissions', opts.baseuri, opts.organization, opts.roleName);
   var requestOptions = {
     uri: uri,
     method:'GET',

--- a/lib/commands/getkvmmap.js
+++ b/lib/commands/getkvmmap.js
@@ -31,14 +31,14 @@ module.exports.run = function(opts, cb) {
     console.log('getkvmmap: %j', opts);
   }
 
-  var uri = util.format('%s/v1/o/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.mapName);
+  var uri = util.format('%s/v1/organizations/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.mapName);
   
   if (opts.api) {
-    uri = util.format('%s/v1/o/%s/apis/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.api, opts.mapName);
+    uri = util.format('%s/v1/organizations/%s/apis/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.api, opts.mapName);
   }
 
   if (opts.environment) {
-    uri = util.format('%s/v1/o/%s/e/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.environment, opts.mapName);
+    uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s', opts.baseuri, opts.organization, opts.environment, opts.mapName);
   }
 
 	var requestOpts = {

--- a/lib/commands/getlogs.js
+++ b/lib/commands/getlogs.js
@@ -85,7 +85,7 @@ module.exports.run = function(opts, cb) {
 
 function makeOneRequest(request, opts, outStream, cb) {
   var uri = util.format(
-    '%s/v1/o/%s/e/%s/apis/%s/cachedlogs/categories/%s',
+    '%s/v1/organizations/%s/environments/%s/apis/%s/cachedlogs/categories/%s',
     opts.baseuri, opts.organization, opts.environment,
     opts.api, opts.category);
   if (opts.timezone) {
@@ -116,7 +116,7 @@ function makeOneRequest(request, opts, outStream, cb) {
 
 function makeStreamRequest(request, opts, outStream, cb, state) {
   var uri = util.format(
-    '%s/v1/o/%s/e/%s/apis/%s/cachedlogs/categories/%s?getState=true',
+    '%s/v1/organizations/%s/environments/%s/apis/%s/cachedlogs/categories/%s?getState=true',
     opts.baseuri, opts.organization, opts.environment,
     opts.api, opts.category);
   if (state) {

--- a/lib/commands/list-TargetServers.js
+++ b/lib/commands/list-TargetServers.js
@@ -23,7 +23,7 @@ module.exports.run = function(opts, cb) {
   if (opts.debug) {
     console.log('listTargetServers: %j', opts);
   }
-  var uri = util.format('%s/v1/o/%s/e/%s/targetservers', opts.baseuri, opts.organization, opts.environment);
+  var uri = util.format('%s/v1/organizations/%s/environments/%s/targetservers', opts.baseuri, opts.organization, opts.environment);
   var requestOptions = {
     uri: uri,
     method:'GET',

--- a/lib/commands/listRoleUsers.js
+++ b/lib/commands/listRoleUsers.js
@@ -23,7 +23,7 @@ module.exports.run = function(opts, cb) {
     console.log('getRoleUsers: %j', opts);
   }
 
-  var uri = util.format('%s/v1/o/%s/userroles/%s/users', opts.baseuri, opts.organization, opts.roleName);
+  var uri = util.format('%s/v1/organizations/%s/userroles/%s/users', opts.baseuri, opts.organization, opts.roleName);
   var requestOptions = {
     uri: uri,
     method:'GET',

--- a/lib/commands/listRoles.js
+++ b/lib/commands/listRoles.js
@@ -17,7 +17,7 @@ module.exports.run = function(opts, cb) {
   if (opts.debug) {
     console.log('listRoles: %j', opts);
   }
-  var uri = util.format('%s/v1/o/%s/userroles', opts.baseuri, opts.organization);
+  var uri = util.format('%s/v1/organizations/%s/userroles', opts.baseuri, opts.organization);
   var requestOptions = {
     uri: uri,
     method:'GET',

--- a/lib/commands/listdeployments.js
+++ b/lib/commands/listdeployments.js
@@ -48,12 +48,12 @@ module.exports.run = function(opts, cb) {
   }
 
   if (opts.api && !opts.environment) {
-    uri = util.format('%s/v1/o/%s/apis/%s/deployments',
+    uri = util.format('%s/v1/organizations/%s/apis/%s/deployments',
                       opts.baseuri, opts.organization, opts.api);
     parser = parseAPIBody;
 
   } else if (opts.environment && !opts.api) {
-    uri = util.format('%s/v1/o/%s/e/%s/deployments',
+    uri = util.format('%s/v1/organizations/%s/environments/%s/deployments',
                       opts.baseuri, opts.organization, opts.environment);
     parser = parseEnvironmentBody;
 

--- a/lib/commands/listsharedflowdeployments.js
+++ b/lib/commands/listsharedflowdeployments.js
@@ -44,12 +44,12 @@ module.exports.run = function(opts, cb) {
   }
 
   if (opts.name && !opts.environment) {
-    uri = util.format('%s/v1/o/%s/sharedflows/%s/deployments',
+    uri = util.format('%s/v1/organizations/%s/sharedflows/%s/deployments',
                       opts.baseuri, opts.organization, opts.name);
     parser = parseAPIBody;
 
   } else if (opts.environment && !opts.name) {
-    uri = util.format('%s/v1/o/%s/e/%s/deployments?sharedFlows=true',
+    uri = util.format('%s/v1/organizations/%s/environments/%s/deployments?sharedFlows=true',
                       opts.baseuri, opts.organization, opts.environment);
     parser = parseEnvironmentBody;
 

--- a/lib/commands/parsedeployments.js
+++ b/lib/commands/parsedeployments.js
@@ -124,7 +124,7 @@ function fillInProxies(deployment, opts, request, done) {
   var vhosts = {};
 
   // First get the list of proxies
-  var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/proxies',
+  var uri = util.format('%s/v1/organizations/%s/apis/%s/revisions/%d/proxies',
                         opts.baseuri, opts.organization, deployment.name,
                         deployment.revision);
   if (opts.debug) {
@@ -152,7 +152,7 @@ function fillInProxies(deployment, opts, request, done) {
 
 function fillInProxy(deployment, vhosts, proxyName, opts, request, done) {
   // Get the proxy info
-  var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/proxies/%s',
+  var uri = util.format('%s/v1/organizations/%s/apis/%s/revisions/%d/proxies/%s',
                         opts.baseuri, opts.organization, deployment.name,
                         deployment.revision, proxyName);
   if (opts.debug) {
@@ -187,7 +187,7 @@ function fillInVirtualHost(deployment, vhosts, vhostName, proxyBasePath, opts, r
     addProxyUri(deployment, vhosts[vhostName], proxyBasePath);
     done();
   } else {
-    var uri = util.format('%s/v1/o/%s/e/%s/virtualhosts/%s',
+    var uri = util.format('%s/v1/organizations/%s/environments/%s/virtualhosts/%s',
                           opts.baseuri, opts.organization, deployment.environment,
                           vhostName);
     if (opts.debug) {

--- a/lib/commands/removeUserRole.js
+++ b/lib/commands/removeUserRole.js
@@ -28,7 +28,7 @@ module.exports.run = function(opts, cb) {
     console.log('removeUserRole: %j', opts);
   }
 
-  var uri = util.format('%s/v1/o/%s/userroles/%s/users/%s', opts.baseuri, opts.organization, opts.roleName, opts.email );
+  var uri = util.format('%s/v1/organizations/%s/userroles/%s/users/%s', opts.baseuri, opts.organization, opts.roleName, opts.email );
   var requestOptions = {
     uri: uri,
     method:'DELETE',

--- a/lib/commands/setRolePermissions.js
+++ b/lib/commands/setRolePermissions.js
@@ -34,7 +34,7 @@ module.exports.run = function(opts, cb) {
   var payload  = {
    "resourcePermission" : permissions
   };
-  var uri = util.format('%s/v1/o/%s/userroles/%s/resourcepermissions', opts.baseuri, opts.organization, opts.roleName);
+  var uri = util.format('%s/v1/organizations/%s/userroles/%s/resourcepermissions', opts.baseuri, opts.organization, opts.roleName);
   var requestOptions = {
     uri: uri,
     method:'POST',

--- a/lib/commands/undeploy.js
+++ b/lib/commands/undeploy.js
@@ -108,7 +108,7 @@ function getDeploymentInfo(opts, request, done) {
   }
 
   // Find out which revision we should be undeploying
-  request.get(util.format('%s/v1/o/%s/environments/%s/apis/%s/deployments',
+  request.get(util.format('%s/v1/organizations/%s/environments/%s/apis/%s/deployments',
                opts.baseuri, opts.organization, opts.environment, opts.api),
   function(err, req, body) {
       if (err) {
@@ -139,7 +139,7 @@ function undeploy(opts, request, done) {
                 opts.api, opts.environment);
   }
 
-  var uri = util.format('%s/v1/o/%s/apis/%s/deployments',
+  var uri = util.format('%s/v1/organizations/%s/apis/%s/deployments',
                           opts.baseuri, opts.organization, opts.api);
   if (opts.debug) {
     console.log('Going to POST to %s', uri);

--- a/lib/commands/undeploysharedflow.js
+++ b/lib/commands/undeploysharedflow.js
@@ -108,7 +108,7 @@ function getDeploymentInfo(opts, request, done) {
 
   // Find out which revision we should be undeploying
 
-  request.get(util.format('%s/v1/o/%s/sharedflows/%s/deployments',
+  request.get(util.format('%s/v1/organizations/%s/sharedflows/%s/deployments',
     opts.baseuri, opts.organization, opts.name),
     function (err, req, body) {
       if (err) {
@@ -151,7 +151,7 @@ function undeploy(opts, request, done) {
       opts.name, opts.environment);
   }
 
-  var uri = util.format('%s/v1/o/%s/e/%s/sharedflows/%s/revisions/%s/deployments',
+  var uri = util.format('%s/v1/organizations/%s/environments/%s/sharedflows/%s/revisions/%s/deployments',
     opts.baseuri, opts.organization, opts.environment, opts.name, opts.deploymentVersion);
   if (opts.debug) {
     console.log('Going to POST to %s', uri);

--- a/lib/commands/updateKVMentry.js
+++ b/lib/commands/updateKVMentry.js
@@ -37,17 +37,17 @@ module.exports.run = function (opts, cb) {
     console.log('updateKVMentry: %j', opts);
   }
 
-  var uri = util.format('%s/v1/o/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.mapName, opts.entryName);
+  var uri = util.format('%s/v1/organizations/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.mapName, opts.entryName);
   var payload = {
     "name": opts.entryName,
     "value": opts.entryValue
   }
   if (opts.api) {
-    uri = util.format('%s/v1/o/%s/apis/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.api, opts.mapName, opts.entryName);
+    uri = util.format('%s/v1/organizations/%s/apis/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.api, opts.mapName, opts.entryName);
   }
 
   if (opts.environment) {
-    uri = util.format('%s/v1/o/%s/e/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.environment, opts.mapName, opts.entryName);
+    uri = util.format('%s/v1/organizations/%s/environments/%s/keyvaluemaps/%s/entries/%s', opts.baseuri, opts.organization, opts.environment, opts.mapName, opts.entryName);
   }
 
   var requestOpts = {

--- a/lib/commands/verifyUserRole.js
+++ b/lib/commands/verifyUserRole.js
@@ -28,7 +28,7 @@ module.exports.run = function(opts, cb) {
     console.log('verifyUserRole: %j', opts);
   }
 
-  var uri = util.format('%s/v1/o/%s/userroles/%s/users/%s', opts.baseuri, opts.organization, opts.roleName, opts.email );
+  var uri = util.format('%s/v1/organizations/%s/userroles/%s/users/%s', opts.baseuri, opts.organization, opts.roleName, opts.email );
   var requestOptions = {
     uri: uri,
     method:'GET',

--- a/lib/deploycommon.js
+++ b/lib/deploycommon.js
@@ -24,7 +24,7 @@ module.exports.createApiProxy = function(opts, request, done) {
   var rootDoc = mustache.render('<APIProxy name="{{api}}"/>', opts);
   var rootEntryName = opts.api + '.xml';
 
-  var uri = util.format('%s/v1/o/%s/apis?action=import&validate=false&name=%s',
+  var uri = util.format('%s/v1/organizations/%s/apis?action=import&validate=false&name=%s',
                         opts.baseuri, opts.organization, opts.api);
   if (opts.debug) {
     console.log('Calling %s', uri);
@@ -77,7 +77,7 @@ module.exports.createProxy = function(opts, request, done) {
     console.log('proxy = %s', targetDoc);
   }
 
-  var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/proxies?name=default',
+  var uri = util.format('%s/v1/organizations/%s/apis/%s/revisions/%d/proxies?name=default',
               opts.baseuri, opts.organization, opts.api,
               opts.deploymentVersion);
   if (opts.verbose) {
@@ -113,7 +113,7 @@ module.exports.deployProxy = function(opts, request, done) {
 
   function deployToEnvironment(environment, done) {
 
-    var uri = util.format('%s/v1/o/%s/e/%s/apis/%s/revisions/%d/deployments',
+    var uri = util.format('%s/v1/organizations/%s/environments/%s/apis/%s/revisions/%d/deployments',
       opts.baseuri, opts.organization, environment, opts.api,
       opts.deploymentVersion);
 
@@ -256,7 +256,7 @@ module.exports.uploadSource = function(sourceDir, type, opts, request, done) {
 
     async.eachLimit(entries, opts.asynclimit, function(entry, entryDone) {
       var uri =
-        util.format('%s/v1/o/%s/apis/%s/revisions/%d/resources?type=%s&name=%s',
+        util.format('%s/v1/organizations/%s/apis/%s/revisions/%d/resources?type=%s&name=%s',
           opts.baseuri, opts.organization, opts.api,
           opts.deploymentVersion, type, entry.resourceName);
       if (entry.directory) {


### PR DESCRIPTION
Apigee X and Apigee Hybrid uses apigee.googleapis.com and does not support the abbreviated organization '/o' and environment paths '/e/

This PR updates the URL using the full name instead of the abbreviated ones.