### PR TITLE
docs: update README to include history and remote tests sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ For a similar tool that works with X or hybrid, see [here](https://github.com/sr
 * [What you need to know about apigeetool](#whatyouneed)
 * [Command reference and examples](#reference)
 * [SDK reference and examples](#sdkreference)
-* [Original tool](#original)
+* [Some History](#history)
+* [Running Remote Tests](#remotetests)
 * [Contribution](#contrib)
 
 # <a name="installation"></a>Installation


### PR DESCRIPTION
## Change Summary

This PR:

1. Removes the broken link to the [Original tool](https://github.com/apigee/apigeetool-node/blob/master/README.md#original) section.
2. Adds new links to the following sections:
    1. [Some History](https://github.com/apigee/apigeetool-node/blob/master/README.md#some-history)
    2. [Running Remote Tests](https://github.com/apigee/apigeetool-node/blob/master/README.md#running-remote-tests)

Fixes #247